### PR TITLE
Add role tables and helpers for user authorization

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, session, url_for
 import hashlib
-from services.db import get_connection
+from services.db import get_connection, get_roles_by_user
 
 auth_bp = Blueprint('auth', __name__)
 
@@ -15,16 +15,19 @@ def login():
         conn = get_connection()
         c = conn.cursor()
         c.execute(
-            'SELECT id, username, password, rol FROM usuarios WHERE username = %s AND password = %s',
+            'SELECT id, username, password FROM usuarios WHERE username = %s AND password = %s',
             (username, hashed)
         )
         user = c.fetchone()
         conn.close()
 
         if user:
-            # user tuple: (id, username, password, rol)
+            # user tuple: (id, username, password)
             session['user'] = user[1]
-            session['rol'] = user[3]
+            roles = get_roles_by_user(user[0])
+            session['roles'] = roles
+            # compatibilidad con código existente
+            session['rol'] = roles[0] if roles else None
             return redirect(url_for('chat.index'))  # redirige a la ruta principal
         else:
             error = 'Usuario o contraseña incorrectos'
@@ -35,3 +38,4 @@ def login():
 def logout():
     session.clear()
     return redirect(url_for('auth.login'))
+

--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -7,7 +7,7 @@ config_bp = Blueprint('configuracion', __name__)
 @config_bp.route('/configuracion', methods=['GET', 'POST'])
 def configuracion():
     # Solo admin
-    if "user" not in session or session.get("rol") != "admin":
+    if "user" not in session or 'admin' not in session.get('roles', []):
         return redirect(url_for("auth.login"))
 
     conn = get_connection()
@@ -94,7 +94,7 @@ def configuracion():
 
 @config_bp.route('/eliminar_regla/<int:regla_id>', methods=['POST'])
 def eliminar_regla(regla_id):
-    if "user" not in session or session.get("rol") != "admin":
+    if "user" not in session or 'admin' not in session.get('roles', []):
         return redirect(url_for("auth.login"))
 
     conn = get_connection()
@@ -110,7 +110,7 @@ def eliminar_regla(regla_id):
 
 @config_bp.route('/botones', methods=['GET', 'POST'])
 def botones():
-    if "user" not in session or session.get("rol") != "admin":
+    if "user" not in session or 'admin' not in session.get('roles', []):
         return redirect(url_for("auth.login"))
 
     conn = get_connection()
@@ -147,7 +147,7 @@ def botones():
 
 @config_bp.route('/eliminar_boton/<int:boton_id>', methods=['POST'])
 def eliminar_boton(boton_id):
-    if "user" not in session or session.get("rol") != "admin":
+    if "user" not in session or 'admin' not in session.get('roles', []):
         return redirect(url_for("auth.login"))
 
     conn = get_connection()


### PR DESCRIPTION
## Summary
- introduce roles and user_roles tables with migration from legacy usuarios.rol
- seed admin role/user and provide helpers for retrieving and assigning roles
- update authentication and admin-only routes to use new role mapping

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a783dd6308323b38509193824883e