### PR TITLE
Track roles triggered by chatbot rules

### DIFF
--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -20,7 +20,8 @@ def configuracion():
             wb = load_workbook(archivo)
             hoja = wb.active
             for fila in hoja.iter_rows(min_row=2, values_only=True):
-                step, input_text, respuesta, siguiente_step, tipo, opciones = fila
+                datos = list(fila) + [None] * 7
+                step, input_text, respuesta, siguiente_step, tipo, opciones, rol_keyword = datos[:7]
                 c.execute(
                     "SELECT id FROM reglas WHERE step = %s AND input_text = %s",
                     (step, input_text)
@@ -34,16 +35,17 @@ def configuracion():
                            SET respuesta = %s,
                                siguiente_step = %s,
                                tipo = %s,
-                               opciones = %s
+                               opciones = %s,
+                               rol_keyword = %s
                          WHERE id = %s
                         """,
-                        (respuesta, siguiente_step, tipo, opciones, regla_id)
+                        (respuesta, siguiente_step, tipo, opciones, rol_keyword, regla_id)
                     )
                 else:
                     c.execute(
-                        "INSERT INTO reglas (step, input_text, respuesta, siguiente_step, tipo, opciones)"
-                        " VALUES (%s, %s, %s, %s, %s, %s)",
-                        (step, input_text, respuesta, siguiente_step, tipo, opciones)
+                        "INSERT INTO reglas (step, input_text, respuesta, siguiente_step, tipo, opciones, rol_keyword)"
+                        " VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                        (step, input_text, respuesta, siguiente_step, tipo, opciones, rol_keyword)
                     )
             conn.commit()
         else:
@@ -54,6 +56,7 @@ def configuracion():
             siguiente_step = request.form.get('siguiente_step', None)
             tipo = request.form.get('tipo', 'texto')
             opciones = request.form.get('opciones', '')
+            rol_keyword = request.form.get('rol_keyword', None)
 
             c.execute(
                 "SELECT id FROM reglas WHERE step = %s AND input_text = %s",
@@ -68,22 +71,23 @@ def configuracion():
                        SET respuesta = %s,
                            siguiente_step = %s,
                            tipo = %s,
-                           opciones = %s
+                           opciones = %s,
+                           rol_keyword = %s
                      WHERE id = %s
                     """,
-                    (respuesta, siguiente_step, tipo, opciones, regla_id)
+                    (respuesta, siguiente_step, tipo, opciones, rol_keyword, regla_id)
                 )
             else:
                 c.execute(
-                    "INSERT INTO reglas (step, input_text, respuesta, siguiente_step, tipo, opciones)"
-                    " VALUES (%s, %s, %s, %s, %s, %s)",
-                    (step, input_text, respuesta, siguiente_step, tipo, opciones)
+                    "INSERT INTO reglas (step, input_text, respuesta, siguiente_step, tipo, opciones, rol_keyword)"
+                    " VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                    (step, input_text, respuesta, siguiente_step, tipo, opciones, rol_keyword)
                 )
             conn.commit()
 
     # Listar todas las reglas
     c.execute(
-        "SELECT id, step, input_text, respuesta, siguiente_step, tipo, opciones"
+        "SELECT id, step, input_text, respuesta, siguiente_step, tipo, opciones, rol_keyword"
         " FROM reglas"
         " ORDER BY step, id"
     )

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -148,14 +148,21 @@ def webhook():
 
                 conn = get_connection(); c = conn.cursor()
                 c.execute(
-                    "SELECT respuesta, siguiente_step, tipo, opciones "
+                    "SELECT respuesta, siguiente_step, tipo, opciones, rol_keyword "
                     "FROM reglas WHERE step=%s AND input_text=%s",
                     ('menu_principal','iniciar')
                 )
                 row = c.fetchone(); conn.close()
                 if row:
-                    resp, next_step, tipo_resp, opts = row
+                    resp, next_step, tipo_resp, opts, rol_kw = row
                     enviar_mensaje(from_number, resp, tipo_respuesta=tipo_resp, opciones=opts)
+                    if rol_kw:
+                        conn2 = get_connection(); c2 = conn2.cursor()
+                        c2.execute(
+                            "INSERT IGNORE INTO chat_roles (numero, rol_keyword) VALUES (%s, %s)",
+                            (from_number, rol_kw)
+                        )
+                        conn2.commit(); conn2.close()
                     if next_step:
                         user_steps[from_number] = next_step
                 return jsonify({'status':'reiniciado'}), 200
@@ -166,14 +173,21 @@ def webhook():
                 user_steps[from_number] = step
                 conn = get_connection(); c = conn.cursor()
                 c.execute(
-                    "SELECT respuesta, siguiente_step, tipo, opciones "
+                    "SELECT respuesta, siguiente_step, tipo, opciones, rol_keyword "
                     "FROM reglas WHERE step=%s AND input_text=%s",
                     (step,'iniciar')
                 )
                 row = c.fetchone(); conn.close()
                 if row:
-                    resp, next_step, *_ = row
+                    resp, next_step, _, _, rol_kw = row
                     enviar_mensaje(from_number, resp)
+                    if rol_kw:
+                        conn2 = get_connection(); c2 = conn2.cursor()
+                        c2.execute(
+                            "INSERT IGNORE INTO chat_roles (numero, rol_keyword) VALUES (%s, %s)",
+                            (from_number, rol_kw)
+                        )
+                        conn2.commit(); conn2.close()
                     if next_step:
                         user_steps[from_number] = next_step
                 return jsonify({'status':'sent_welcome'}), 200
@@ -214,14 +228,21 @@ def webhook():
 
             conn = get_connection(); c = conn.cursor()
             c.execute(
-                "SELECT respuesta, siguiente_step, tipo, opciones "
+                "SELECT respuesta, siguiente_step, tipo, opciones, rol_keyword "
                 "FROM reglas WHERE step=%s AND input_text=%s",
                 (step, text)
             )
             row = c.fetchone(); conn.close()
             if row:
-                resp, next_step, tipo_resp, opts = row
+                resp, next_step, tipo_resp, opts, rol_kw = row
                 enviar_mensaje(from_number, resp, tipo_respuesta=tipo_resp, opciones=opts)
+                if rol_kw:
+                    conn2 = get_connection(); c2 = conn2.cursor()
+                    c2.execute(
+                        "INSERT IGNORE INTO chat_roles (numero, rol_keyword) VALUES (%s, %s)",
+                        (from_number, rol_kw)
+                    )
+                    conn2.commit(); conn2.close()
                 if next_step:
                     user_steps[from_number] = next_step
             else:

--- a/services/db.py
+++ b/services/db.py
@@ -59,7 +59,8 @@ def init_db():
       respuesta TEXT NOT NULL,
       siguiente_step TEXT,
       tipo VARCHAR(20) NOT NULL DEFAULT 'texto',
-      opciones TEXT
+      opciones TEXT,
+      rol_keyword VARCHAR(50)
     );
     """)
 
@@ -76,6 +77,16 @@ def init_db():
     CREATE TABLE IF NOT EXISTS alias (
       numero VARCHAR(20) PRIMARY KEY,
       nombre VARCHAR(100)
+    );
+    """)
+
+    # chat_roles
+    c.execute("""
+    CREATE TABLE IF NOT EXISTS chat_roles (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      numero VARCHAR(20) NOT NULL,
+      rol_keyword VARCHAR(50) NOT NULL,
+      UNIQUE KEY uniq_chat_roles (numero, rol_keyword)
     );
     """)
 

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -90,6 +90,9 @@
             <option value="lista">Lista</option> <!-- ✅ agrega esta -->
         </select>
 
+        <label for="rol_keyword">Rol keyword:</label>
+        <input type="text" id="rol_keyword" name="rol_keyword">
+
         <label for="opciones">Opciones (solo para listas, formato JSON):</label><br>
         <textarea name="opciones" rows="6" cols="60" placeholder='[{"title":"Rápido","rows":[{"id":"express","title":"Express","description":"1 día"}]}]'></textarea>
 
@@ -128,6 +131,7 @@
             <th>Respuesta</th>
             <th>Siguiente paso</th>
             <th>Tipo</th>
+            <th>Rol</th>
             <th>Opciones</th>
             <th>Acción</th>
         </tr>
@@ -139,6 +143,7 @@
             <td>{{ regla[3] }}</td>
             <td>{{ regla[4] or '-' }}</td>
             <td>{{ regla[5] }}</td>
+            <td>{{ regla[7] or '-' }}</td>
             <td><pre style="white-space: pre-wrap;">{{ regla[6] }}</pre></td>
             <td>
                 <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla[0]) }}">


### PR DESCRIPTION
## Summary
- add `rol_keyword` column to `reglas` and create `chat_roles` link table
- record triggered rule's role for a user during webhook handling
- expose role keyword in rule configuration interface

## Testing
- `python -m py_compile services/db.py routes/configuracion.py routes/webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7843439c8323bc6ea6e13599555b