### PR TITLE
Use Werkzeug password hashing for users

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, session, url_for
-import hashlib
+from werkzeug.security import check_password_hash
 from services.db import get_connection
 
 auth_bp = Blueprint('auth', __name__)
@@ -10,18 +10,17 @@ def login():
     if request.method == 'POST':
         username = request.form.get('username')
         password = request.form.get('password')
-        hashed = hashlib.sha256(password.encode()).hexdigest()
 
         conn = get_connection()
         c = conn.cursor()
         c.execute(
-            'SELECT id, username, password, rol FROM usuarios WHERE username = %s AND password = %s',
-            (username, hashed)
+            'SELECT id, username, password, rol FROM usuarios WHERE username = %s',
+            (username,)
         )
         user = c.fetchone()
         conn.close()
 
-        if user:
+        if user and check_password_hash(user[2], password):
             # user tuple: (id, username, password, rol)
             session['user'] = user[1]
             session['rol'] = user[3]

--- a/scripts/rehash_passwords.py
+++ b/scripts/rehash_passwords.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""One-time script to upgrade stored user passwords to Werkzeug hashes."""
+import hashlib
+from getpass import getpass
+
+from werkzeug.security import generate_password_hash
+
+from services.db import get_connection
+
+
+def main():
+    conn = get_connection()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute("SELECT id, username, password FROM usuarios")
+
+    for user in cursor.fetchall():
+        if user["password"].startswith("pbkdf2:"):
+            print(f"Skipping {user['username']}: already migrated")
+            continue
+
+        print(f"Rehashing password for {user['username']}")
+        plain = getpass("Enter current password: ")
+        if hashlib.sha256(plain.encode()).hexdigest() != user["password"]:
+            print("Password mismatch; skipping")
+            continue
+
+        new_hash = generate_password_hash(plain)
+        cursor.execute(
+            "UPDATE usuarios SET password = %s WHERE id = %s",
+            (new_hash, user["id"]),
+        )
+        conn.commit()
+
+    cursor.close()
+    conn.close()
+    print("Migration complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/db.py
+++ b/services/db.py
@@ -1,6 +1,5 @@
 import mysql.connector
-from datetime import datetime
-import hashlib
+from werkzeug.security import generate_password_hash
 from config import Config
 
 def get_connection():
@@ -80,7 +79,7 @@ def init_db():
     """)
 
     # usuario admin inicial
-    hashed = hashlib.sha256('admin123'.encode()).hexdigest()
+    hashed = generate_password_hash('admin123')
     c.execute("""
     INSERT INTO usuarios (username, password, rol)
       SELECT %s, %s, 'admin'


### PR DESCRIPTION
## Summary
- Securely hash initial admin password with Werkzeug instead of manual SHA-256.
- Validate logins using `check_password_hash` to match new hashing scheme.
- Provide `scripts/rehash_passwords.py` to upgrade existing SHA-256 hashes.

## Testing
- `python -m py_compile services/db.py routes/auth_routes.py scripts/rehash_passwords.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a78445cd8832391587a2fd0b8a332