### PR TITLE
Use English field names for roles

### DIFF
--- a/routes/roles_routes.py
+++ b/routes/roles_routes.py
@@ -16,7 +16,7 @@ def roles():
     conn = get_connection()
     c = conn.cursor()
 
-    c.execute('SELECT id, nombre, keywords FROM roles ORDER BY nombre')
+    c.execute('SELECT id, name, keyword FROM roles ORDER BY name')
     roles = c.fetchall()
 
     c.execute('''
@@ -39,11 +39,11 @@ def roles():
 def crear_rol():
     if not _is_admin():
         return redirect(url_for('auth.login'))
-    nombre = request.form['nombre']
-    keywords = request.form.get('keywords', '')
+    name = request.form['name']
+    keyword = request.form.get('keyword', '')
     conn = get_connection()
     c = conn.cursor()
-    c.execute('INSERT INTO roles (nombre, keywords) VALUES (%s, %s)', (nombre, keywords))
+    c.execute('INSERT INTO roles (name, keyword) VALUES (%s, %s)', (name, keyword))
     conn.commit()
     conn.close()
     return redirect(url_for('roles.roles'))
@@ -53,11 +53,11 @@ def crear_rol():
 def editar_rol(rol_id):
     if not _is_admin():
         return redirect(url_for('auth.login'))
-    nombre = request.form['nombre']
-    keywords = request.form.get('keywords', '')
+    name = request.form['name']
+    keyword = request.form.get('keyword', '')
     conn = get_connection()
     c = conn.cursor()
-    c.execute('UPDATE roles SET nombre=%s, keywords=%s WHERE id=%s', (nombre, keywords, rol_id))
+    c.execute('UPDATE roles SET name=%s, keyword=%s WHERE id=%s', (name, keyword, rol_id))
     conn.commit()
     conn.close()
     return redirect(url_for('roles.roles'))

--- a/templates/roles.html
+++ b/templates/roles.html
@@ -7,14 +7,14 @@
 <body>
     <h2>Roles</h2>
     <form action="{{ url_for('roles.crear_rol') }}" method="post">
-        <input type="text" name="nombre" placeholder="Nombre" required>
-        <input type="text" name="keywords" placeholder="Keywords">
+        <input type="text" name="name" placeholder="Nombre" required>
+        <input type="text" name="keyword" placeholder="Palabra clave">
         <button type="submit">Crear</button>
     </form>
     <table border="1" cellpadding="5" cellspacing="0">
         <tr>
             <th>Nombre</th>
-            <th>Keywords</th>
+            <th>Palabra clave</th>
             <th>Usuarios</th>
             <th>Acciones</th>
         </tr>
@@ -28,8 +28,8 @@
                     <button type="submit">Eliminar</button>
                 </form>
                 <form action="{{ url_for('roles.editar_rol', rol_id=rol[0]) }}" method="post" style="display:inline;">
-                    <input type="text" name="nombre" value="{{ rol[1] }}" required>
-                    <input type="text" name="keywords" value="{{ rol[2] }}">
+                    <input type="text" name="name" value="{{ rol[1] }}" required>
+                    <input type="text" name="keyword" value="{{ rol[2] }}">
                     <button type="submit">Actualizar</button>
                 </form>
             </td>


### PR DESCRIPTION
## Summary
- switch role SQL queries to use `name` and `keyword` columns
- update role management forms to submit `name` and `keyword`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a8218a998832383c481e36401b5b8