### PR TITLE
Use numeric role IDs when filtering chats

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -21,11 +21,9 @@ def index():
     conn = get_connection()
     c    = conn.cursor()
     rol  = session.get('rol')
-    role_id = None
-    if rol != 'admin':
-        c.execute("SELECT id FROM roles WHERE keyword=%s", (rol,))
-        row = c.fetchone()
-        role_id = row[0] if row else None
+    c.execute("SELECT id FROM roles WHERE keyword=%s", (rol,))
+    row = c.fetchone()
+    role_id = row[0] if row else None
 
     # Lista de chats únicos filtrados por rol
     if rol == 'admin':
@@ -60,7 +58,7 @@ def index():
     botones = c.fetchall()
 
     conn.close()
-    return render_template('index.html', chats=chats, botones=botones, rol=rol)
+    return render_template('index.html', chats=chats, botones=botones, rol=rol, role_id=role_id)
 
 @chat_bp.route('/get_chat/<numero>')
 def get_chat(numero):

--- a/templates/index.html
+++ b/templates/index.html
@@ -285,6 +285,7 @@
       const chatBoxEl  = document.getElementById('chatBox');
       const botoneraEl = document.getElementById('botonera');
       const userRole   = "{{ rol }}";
+      const userRoleId = {{ role_id | tojson }};
 
       // Mostrar u ocultar menú settings
       const settingsBtn = document.getElementById('settingsBtn');
@@ -304,8 +305,8 @@
             chatListEl.innerHTML='';
             data.forEach(c => {
               if (userRole !== 'admin') {
-                const roles = c.roles ? c.roles.split(',') : [];
-                if (!roles.includes(userRole)) return;
+                const roles = c.roles ? c.roles.split(',').map(Number) : [];
+                if (!roles.includes(userRoleId)) return;
               }
               const li = document.createElement('li');
               li.textContent = c.alias ? `${c.alias} (${c.numero})` : c.numero;


### PR DESCRIPTION
## Summary
- Retrieve numeric role ID for logged-in user and pass it to index template
- Filter chat list by matching numeric role IDs

## Testing
- `python -m py_compile routes/chat_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4a4b285c83239e8eebf977597219