### PR TITLE
Validate user roles during login and allow role selection

### DIFF
--- a/templates/select_role.html
+++ b/templates/select_role.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Seleccionar rol</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', sans-serif;
+            background: linear-gradient(to right, #2c3e50, #4ca1af);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .box {
+            background-color: white;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.2);
+            width: 100%;
+            max-width: 400px;
+            text-align: center;
+        }
+        select {
+            width: 100%;
+            padding: 10px 12px;
+            margin-bottom: 20px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+        button {
+            width: 100%;
+            padding: 12px;
+            background-color: #4ca1af;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            font-weight: bold;
+            font-size: 15px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #3c8c99;
+        }
+        .error {
+            color: red;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="box">
+        <h2>Selecciona un rol</h2>
+        <form method="POST" action="{{ url_for('auth.login') }}">
+            <select name="rol" required>
+                {% for r in roles %}
+                <option value="{{ r }}">{{ r }}</option>
+                {% endfor %}
+            </select>
+            {% if error %}
+            <div class="error">{{ error }}</div>
+            {% endif %}
+            <button type="submit">Ingresar</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Prevent session creation when a user has no roles and show an error
- Add role selection step during login when multiple roles are available
- Create `select_role.html` template to choose a role

## Testing
- `python -m py_compile routes/auth_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_689b541686488323a46f94cb56988110