### PR TITLE
refactor: always persist next step

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -86,8 +86,7 @@ def handle_medicion(numero, texto):
                 )
                 conn2.commit()
             conn2.close()
-        if next_step:
-            set_user_step(numero, next_step.strip().lower())
+        set_user_step(numero, next_step.strip().lower() if next_step else '')
     except Exception:
         enviar_mensaje(numero, "Por favor ingresa la medida correcta.")
     return True
@@ -253,8 +252,7 @@ def webhook():
                             )
                             conn2.commit()
                         conn2.close()
-                    if next_step:
-                        set_user_step(from_number, next_step.strip().lower())
+                    set_user_step(from_number, next_step.strip().lower() if next_step else '')
                 return jsonify({'status':'reiniciado'}), 200
 
             is_new_user = from_number not in user_steps
@@ -284,10 +282,7 @@ def webhook():
                             )
                             conn2.commit()
                         conn2.close()
-                    if next_step:
-                        set_user_step(from_number, next_step.strip().lower())
-                    else:
-                        set_user_step(from_number, 'menu_principal')
+                    set_user_step(from_number, next_step.strip().lower() if next_step else '')
             step = user_steps.get(from_number, '').strip().lower()
             text = text.strip().lower()
 
@@ -315,8 +310,7 @@ def webhook():
                         )
                         conn2.commit()
                     conn2.close()
-                if next_step:
-                    set_user_step(from_number, next_step.strip().lower())
+                set_user_step(from_number, next_step.strip().lower() if next_step else '')
             else:
                 enviar_mensaje(from_number, "No entendí tu respuesta, intenta de nuevo.")
     return jsonify({'status':'received'}), 200


### PR DESCRIPTION
## Summary
- Always call `set_user_step` even when `next_step` is missing so chat state is stored consistently
- Apply same behavior across measurement handlers, restart flow, and final rule processing

## Testing
- `python -m py_compile routes/webhook.py`
- `pytest`
- `python - <<'PY'
from routes import webhook
from services.db import get_connection

numero = '999'
print('before memory:', webhook.user_steps.get(numero))
try:
    webhook.set_user_step(numero, 'test_step')
except Exception as e:
    print('set_user_step error:', e)
print('after memory:', webhook.user_steps.get(numero))
try:
    conn = get_connection()
    cur = conn.cursor()
    cur.execute("SELECT step FROM chat_state WHERE numero=%s", (numero,))
    row = cur.fetchone()
    print('db row:', row)
    conn.close()
except Exception as e:
    print('db check error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b646734b08323aa6ea7171e6e57a5