### PR TITLE
Add audio transcription service using Vosk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 gunicorn
 openpyxl
 mysql-connector-python
+vosk

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -10,6 +10,7 @@ from services.db import (
     delete_chat_state,
 )
 from services.whatsapp_api import download_audio, get_media_url, enviar_mensaje
+from services.transcripcion import transcribir
 from services.global_commands import handle_global_command
 
 webhook_bp = Blueprint('webhook', __name__)
@@ -141,8 +142,9 @@ def webhook():
                 ext        = mime_clean.split('/')[-1]
 
                 audio_bytes = download_audio(media_id)
-                filename    = f"{media_id}.{ext}"
-                path        = os.path.join(Config.UPLOAD_FOLDER, filename)
+                texto = transcribir(audio_bytes)
+                filename = f"{media_id}.{ext}"
+                path = os.path.join(Config.UPLOAD_FOLDER, filename)
                 with open(path, 'wb') as f:
                     f.write(audio_bytes)
 
@@ -150,7 +152,7 @@ def webhook():
 
                 guardar_mensaje(
                     from_number,
-                    "",
+                    texto,
                     'audio',
                     media_id=media_id,
                     media_url=public_url,

--- a/services/transcripcion.py
+++ b/services/transcripcion.py
@@ -1,0 +1,64 @@
+import json
+import os
+import subprocess
+import tempfile
+import wave
+from typing import Optional
+
+from vosk import Model, KaldiRecognizer
+
+_MODEL: Optional[Model] = None
+
+
+def _get_model() -> Model:
+    global _MODEL
+    if _MODEL is None:
+        # Cargar modelo por defecto en español
+        _MODEL = Model(lang="es")
+    return _MODEL
+
+
+def _normalize_audio(input_bytes: bytes) -> str:
+    """Convierte los bytes de audio a un wav mono 16k usando ffmpeg."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".input") as in_f:
+        in_f.write(input_bytes)
+        input_path = in_f.name
+    out_f = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+    out_f.close()
+    output_path = out_f.name
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-ar",
+        "16000",
+        "-ac",
+        "1",
+        output_path,
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    os.remove(input_path)
+    return output_path
+
+
+def transcribir(audio_bytes: bytes) -> str:
+    """Normaliza el audio y devuelve el texto transcrito."""
+    wav_path = _normalize_audio(audio_bytes)
+    model = _get_model()
+    wf = wave.open(wav_path, "rb")
+    rec = KaldiRecognizer(model, wf.getframerate())
+    texto = []
+    while True:
+        data = wf.readframes(4000)
+        if len(data) == 0:
+            break
+        if rec.AcceptWaveform(data):
+            res = json.loads(rec.Result())
+            texto.append(res.get("text", ""))
+    res = json.loads(rec.FinalResult())
+    texto.append(res.get("text", ""))
+    wf.close()
+    os.remove(wav_path)
+    return " ".join(t for t in texto if t).strip()


### PR DESCRIPTION
## Summary
- add Vosk speech-to-text dependency
- implement `services.transcripcion.transcribir` to normalize and transcribe audio
- use transcription in webhook when processing audio messages

## Testing
- `python -m py_compile services/transcripcion.py routes/webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_689bc96cf58083238e15f546b4298e44