### PR TITLE
Add duration check to audio transcription and handle long recordings

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,8 @@ class Config:
     DB_PATH = 'database.db'
     SESSION_TIMEOUT = 600
 
+    MAX_TRANSCRIPTION_DURATION_MS = int(os.getenv('MAX_TRANSCRIPTION_DURATION_MS', 60000))
+
     DB_HOST     = os.getenv('DB_HOST')
     DB_PORT     = int(os.getenv('DB_PORT', 3306))
     DB_USER     = os.getenv('DB_USER')

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -159,7 +159,14 @@ def webhook():
                     mime_type=mime_clean
                 )
 
-                enviar_mensaje(from_number, "Audio recibido correctamente.", tipo='bot')
+                if texto:
+                    enviar_mensaje(from_number, "Audio recibido correctamente.", tipo='bot')
+                else:
+                    enviar_mensaje(
+                        from_number,
+                        "Audio recibido. No se realizó transcripción por exceder la duración permitida.",
+                        tipo='bot'
+                    )
                 continue
 
             if msg_type == 'video':


### PR DESCRIPTION
## Summary
- prevent Vosk transcription for overly long audio by checking duration
- add configurable `MAX_TRANSCRIPTION_DURATION_MS`
- notify user when audio is stored without transcription

## Testing
- `python -m py_compile config.py services/transcripcion.py routes/webhook.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcb153f6083239607d63ccf2c715e