### PR TITLE
Enable async audio transcription via RQ

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ gunicorn
 openpyxl
 mysql-connector-python
 vosk
+
+redis
+rq

--- a/services/job_queue.py
+++ b/services/job_queue.py
@@ -1,0 +1,11 @@
+import os
+from redis import Redis
+from rq import Queue
+
+redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+redis_conn = Redis.from_url(redis_url)
+queue = Queue('default', connection=redis_conn)
+
+def enqueue_transcription(audio_path: str, from_number: str, media_id: str, mime_type: str, public_url: str) -> None:
+    """Enqueue an audio transcription job."""
+    queue.enqueue('services.tasks.process_audio', audio_path, from_number, media_id, mime_type, public_url)

--- a/services/tasks.py
+++ b/services/tasks.py
@@ -1,0 +1,28 @@
+from services.transcripcion import transcribir
+from services.db import guardar_mensaje
+from services.whatsapp_api import enviar_mensaje
+
+
+def process_audio(audio_path: str, from_number: str, media_id: str, mime_type: str, public_url: str) -> None:
+    """Background job to transcribe audio and respond to the user."""
+    with open(audio_path, 'rb') as f:
+        audio_bytes = f.read()
+    texto = transcribir(audio_bytes)
+
+    guardar_mensaje(
+        from_number,
+        texto,
+        'audio',
+        media_id=media_id,
+        media_url=public_url,
+        mime_type=mime_type,
+    )
+
+    if texto:
+        enviar_mensaje(from_number, "Audio recibido correctamente.", tipo='bot')
+    else:
+        enviar_mensaje(
+            from_number,
+            "Audio recibido. No se realizó transcripción por exceder la duración permitida.",
+            tipo='bot',
+        )


### PR DESCRIPTION
## Summary
- add Redis RQ queue and transcription task
- enqueue audio transcription job in webhook and notify user that processing has started

## Testing
- `python -m py_compile routes/webhook.py services/job_queue.py services/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_689bcc14d2608323aeec3513c00882bc