### PR TITLE
Link audio transcriptions to original message records

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -149,7 +149,16 @@ def webhook():
 
                 public_url = url_for('static', filename=f'uploads/{filename}', _external=True)
 
-                enqueue_transcription(path, from_number, media_id, mime_clean, public_url)
+                mensaje_id = guardar_mensaje(
+                    from_number,
+                    "",
+                    'audio',
+                    media_id=media_id,
+                    media_url=public_url,
+                    mime_type=mime_clean,
+                )
+
+                enqueue_transcription(path, from_number, media_id, mime_clean, public_url, mensaje_id)
                 enviar_mensaje(from_number, "Tu audio está siendo procesado.", tipo='bot')
                 continue
 

--- a/services/db.py
+++ b/services/db.py
@@ -198,6 +198,20 @@ def guardar_mensaje(numero, mensaje, tipo, media_id=None, media_url=None, mime_t
         "VALUES (%s, %s, %s, %s, %s, %s, NOW())",
         (numero, mensaje, tipo, media_id, media_url, mime_type)
     )
+    mensaje_id = c.lastrowid
+    conn.commit()
+    conn.close()
+    return mensaje_id
+
+
+def update_mensaje_texto(id_mensaje, texto):
+    """Actualiza el campo `mensaje` de un registro existente."""
+    conn = get_connection()
+    c    = conn.cursor()
+    c.execute(
+        "UPDATE mensajes SET mensaje=%s WHERE id=%s",
+        (texto, id_mensaje),
+    )
     conn.commit()
     conn.close()
 

--- a/services/job_queue.py
+++ b/services/job_queue.py
@@ -6,6 +6,14 @@ redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
 redis_conn = Redis.from_url(redis_url)
 queue = Queue('default', connection=redis_conn)
 
-def enqueue_transcription(audio_path: str, from_number: str, media_id: str, mime_type: str, public_url: str) -> None:
+def enqueue_transcription(audio_path: str, from_number: str, media_id: str, mime_type: str, public_url: str, mensaje_id: int) -> None:
     """Enqueue an audio transcription job."""
-    queue.enqueue('services.tasks.process_audio', audio_path, from_number, media_id, mime_type, public_url)
+    queue.enqueue(
+        'services.tasks.process_audio',
+        audio_path,
+        from_number,
+        media_id,
+        mime_type,
+        public_url,
+        mensaje_id,
+    )

--- a/services/tasks.py
+++ b/services/tasks.py
@@ -1,25 +1,25 @@
 from services.transcripcion import transcribir
-from services.db import guardar_mensaje
+from services.db import update_mensaje_texto
 from services.whatsapp_api import enviar_mensaje
 
 
-def process_audio(audio_path: str, from_number: str, media_id: str, mime_type: str, public_url: str) -> None:
+def process_audio(
+    audio_path: str,
+    from_number: str,
+    media_id: str,
+    mime_type: str,
+    public_url: str,
+    mensaje_id: int,
+) -> None:
     """Background job to transcribe audio and respond to the user."""
     with open(audio_path, 'rb') as f:
         audio_bytes = f.read()
     texto = transcribir(audio_bytes)
 
-    guardar_mensaje(
-        from_number,
-        texto,
-        'audio',
-        media_id=media_id,
-        media_url=public_url,
-        mime_type=mime_type,
-    )
+    update_mensaje_texto(mensaje_id, texto)
 
     if texto:
-        enviar_mensaje(from_number, "Audio recibido correctamente.", tipo='bot')
+        enviar_mensaje(from_number, f"Transcripción lista: {texto}", tipo='bot')
     else:
         enviar_mensaje(
             from_number,


### PR DESCRIPTION
## Summary
- return inserted message ids from `guardar_mensaje` and add `update_mensaje_texto` helper
- store initial audio message and pass its id to the transcription job
- update background job to write transcription text back and notify user

## Testing
- `python -m py_compile services/db.py routes/webhook.py services/job_queue.py services/tasks.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bcd01e774832399072ed5bde6024e