### PR TITLE
Log transcription timing and disable on slow average

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ class Config:
     SESSION_TIMEOUT = 600
 
     MAX_TRANSCRIPTION_DURATION_MS = int(os.getenv('MAX_TRANSCRIPTION_DURATION_MS', 60000))
+    TRANSCRIPTION_MAX_AVG_TIME_SEC = float(os.getenv('TRANSCRIPTION_MAX_AVG_TIME_SEC', 10))
 
     DB_HOST     = os.getenv('DB_HOST')
     DB_PORT     = int(os.getenv('DB_PORT', 3306))


### PR DESCRIPTION
## Summary
- add `TRANSCRIPTION_MAX_AVG_TIME_SEC` configuration for runtime threshold
- time and log each `transcribir` call
- track average transcription runtime and disable transcription if it exceeds the threshold

## Testing
- `python -m py_compile config.py services/transcripcion.py`
- `python -m py_compile services/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_689bcdf8647483239bf2d1bc95f16801