### PR TITLE
Handle Redis connection failures gracefully

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -158,8 +158,26 @@ def webhook():
                     mime_type=mime_clean,
                 )
 
-                enqueue_transcription(path, from_number, media_id, mime_clean, public_url, mensaje_id)
-                enviar_mensaje(from_number, "Tu audio está siendo procesado.", tipo='bot')
+                queued = enqueue_transcription(
+                    path,
+                    from_number,
+                    media_id,
+                    mime_clean,
+                    public_url,
+                    mensaje_id,
+                )
+                if queued:
+                    enviar_mensaje(
+                        from_number,
+                        "Tu audio está siendo procesado.",
+                        tipo='bot'
+                    )
+                else:
+                    enviar_mensaje(
+                        from_number,
+                        "El servicio está temporalmente fuera de línea. Inténtalo más tarde.",
+                        tipo='bot'
+                    )
                 continue
 
             if msg_type == 'video':

--- a/services/job_queue.py
+++ b/services/job_queue.py
@@ -1,19 +1,32 @@
 import os
-from redis import Redis
+import logging
+import redis
 from rq import Queue
 
-redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
-redis_conn = Redis.from_url(redis_url)
-queue = Queue('default', connection=redis_conn)
 
-def enqueue_transcription(audio_path: str, from_number: str, media_id: str, mime_type: str, public_url: str, mensaje_id: int) -> None:
+def enqueue_transcription(
+    audio_path: str,
+    from_number: str,
+    media_id: str,
+    mime_type: str,
+    public_url: str,
+    mensaje_id: int,
+) -> bool:
     """Enqueue an audio transcription job."""
-    queue.enqueue(
-        'services.tasks.process_audio',
-        audio_path,
-        from_number,
-        media_id,
-        mime_type,
-        public_url,
-        mensaje_id,
-    )
+    try:
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        redis_conn = redis.Redis.from_url(redis_url)
+        queue = Queue("default", connection=redis_conn)
+        queue.enqueue(
+            "services.tasks.process_audio",
+            audio_path,
+            from_number,
+            media_id,
+            mime_type,
+            public_url,
+            mensaje_id,
+        )
+        return True
+    except redis.exceptions.ConnectionError as exc:
+        logging.error("Redis connection error: %s", exc)
+        return False


### PR DESCRIPTION
## Summary
- Protect Redis queue operations with try/except and log connection errors
- Notify webhook callers when job queue is unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd15432dc832390a4faa7ddefade9