### PR TITLE
Document audio dependencies for transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ openpyxl para cargar reglas desde archivos Excel
 dotenv para manejar tokens y credenciales
 
 ThreadPoolExecutor para procesar transcripciones de audio en segundo plano (sin necesidad de Redis)
+ffmpeg (binario del sistema) para normalizar los audios antes de la transcripción (instalar manualmente)
 
 ✅ Estado actual
 La app ya está funcionando con:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ gunicorn
 openpyxl
 mysql-connector-python
 vosk
+ffmpeg-python
+concurrent-futures; python_version < "3.2"


### PR DESCRIPTION
## Summary
- List ffmpeg-python and concurrent-futures in requirements
- Document system ffmpeg requirement for audio normalization

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement ffmpeg-python)*
- `python - <<'PY'
from services.transcripcion import transcribir

try:
    print(transcribir(b''))
except Exception as e:
    print('Error:', e)
PY` *(fails: [Errno 2] No such file or directory: 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_689bdac3f8e48323a7ccbee4966dc5cd