### PR TITLE
Check ffmpeg availability before transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ dotenv para manejar tokens y credenciales
 ThreadPoolExecutor para procesar transcripciones de audio en segundo plano (sin necesidad de Redis)
 ffmpeg (binario del sistema) para normalizar los audios antes de la transcripción (instalar manualmente)
 
+## Requisitos
+
+Para ejecutar la aplicación necesitas tener instalado **ffmpeg** en el sistema.
+
+### Linux (Ubuntu/Debian)
+
+```bash
+sudo apt-get update && sudo apt-get install -y ffmpeg
+```
+
+### macOS (Homebrew)
+
+```bash
+brew install ffmpeg
+```
+
+### Docker
+
+Si usas Docker, asegúrate de añadir ffmpeg en la imagen:
+
+```dockerfile
+RUN apt-get update && apt-get install -y ffmpeg
+```
+
 ✅ Estado actual
 La app ya está funcionando con:
 

--- a/services/transcripcion.py
+++ b/services/transcripcion.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 import wave
 import logging
+import shutil
 from typing import Optional
 
 from vosk import Model, KaldiRecognizer
@@ -29,6 +30,11 @@ def _get_model() -> Model:
 
 def _normalize_audio(input_bytes: bytes) -> str:
     """Convierte los bytes de audio a un wav mono 16k usando ffmpeg."""
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise RuntimeError(
+            "ffmpeg no está instalado o no se encuentra en el PATH"
+        )
     with tempfile.NamedTemporaryFile(delete=False, suffix=".input") as in_f:
         in_f.write(input_bytes)
         input_path = in_f.name
@@ -37,7 +43,7 @@ def _normalize_audio(input_bytes: bytes) -> str:
     output_path = out_f.name
 
     cmd = [
-        "ffmpeg",
+        ffmpeg_path,
         "-y",
         "-i",
         input_path,


### PR DESCRIPTION
## Summary
- Ensure ffmpeg is installed before normalizing audio and raise a clear error when missing
- Document ffmpeg installation steps for Linux, macOS, and Docker

## Testing
- `python -m py_compile services/transcripcion.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bdc9dc81c83239f86afc5690a4e31