### PR TITLE
Mostrar rol del usuario en index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -240,6 +240,15 @@
     button:active:after {
       transform:scale(1); opacity:1; transition:0s;
     }
+
+    .role-indicator {
+      position: fixed;
+      bottom: 8px;
+      right: 8px;
+      font-size: 12px;
+      color: rgba(0, 0, 0, 0.4);
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
@@ -281,6 +290,8 @@
       </div>
     </div>
   </div>
+
+  <div class="role-indicator">{{ rol }}</div>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Mostrar el rol activo en la esquina inferior derecha de la página principal
- Añadir estilos discretos para el indicador de rol

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d097fbfb483239c1864870fdd5b77