### PR TITLE
Fix media type suffix for outgoing messages

### DIFF
--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -129,12 +129,15 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
 
     resp = requests.post(url, headers=headers, json=data)
     print(f"[WA API] {resp.status_code} — {resp.text}")
+    tipo_db = tipo
+    if tipo_respuesta in {"image", "audio", "video", "document"} and "_" not in tipo:
+        tipo_db = f"{tipo}_{tipo_respuesta}"
 
     if tipo_respuesta == 'video':
         guardar_mensaje(
             numero,
             mensaje,
-            tipo,
+            tipo_db,
             media_id=None,
             media_url=video_obj.get("link")
         )
@@ -143,7 +146,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
         guardar_mensaje(
             numero,
             mensaje,
-            tipo,
+            tipo_db,
             media_id=None,
             media_url=audio_obj.get("link")
         )
@@ -151,7 +154,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
         guardar_mensaje(
             numero,
             mensaje,
-            tipo,
+            tipo_db,
             media_id=None,
             media_url=opciones
         )


### PR DESCRIPTION
## Summary
- Ensure outgoing media messages store their media type suffix
- Use composed tipo when saving images, audio, video or documents

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d160aadd08323ac77c08d7ac4c81d