### PR TITLE
Add dedicated rules management page

### DIFF
--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -14,8 +14,7 @@ def _require_admin():
     # Debe haber usuario logueado y el rol 'admin' en la lista de roles
     return "user" in session and 'admin' in (session.get('roles') or [])
 
-@config_bp.route('/configuracion', methods=['GET', 'POST'])
-def configuracion():
+def _reglas_view(template_name):
     if not _require_admin():
         return redirect(url_for("auth.login"))
 
@@ -151,9 +150,17 @@ def configuracion():
             "ORDER BY step, id"
         )
         reglas = c.fetchall()
-        return render_template('configuracion.html', reglas=reglas)
+        return render_template(template_name, reglas=reglas)
     finally:
         conn.close()
+
+@config_bp.route('/configuracion', methods=['GET', 'POST'])
+def configuracion():
+    return _reglas_view('configuracion.html')
+
+@config_bp.route('/reglas', methods=['GET', 'POST'])
+def reglas():
+    return _reglas_view('reglas.html')
 
 @config_bp.route('/eliminar_regla/<int:regla_id>', methods=['POST'])
 def eliminar_regla(regla_id):
@@ -165,7 +172,7 @@ def eliminar_regla(regla_id):
     try:
         c.execute("DELETE FROM reglas WHERE id = %s", (regla_id,))
         conn.commit()
-        return redirect(url_for('configuracion.configuracion'))
+        return redirect(url_for('configuracion.reglas'))
     finally:
         conn.close()
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -260,7 +260,7 @@
         <button id="settingsBtn">⚙️</button>
       </div>
       <div id="settingsMenu" class="attach-menu">
-        <a href="{{ url_for('configuracion.configuracion') }}">Configuración</a>
+        <a href="{{ url_for('configuracion.reglas') }}">Reglas</a>
         <a href="{{ url_for('configuracion.botones') }}">Botones</a>
         {% if session.get('roles') and 'admin' in session['roles'] %}
         <a href="{{ url_for('roles.roles') }}">Roles</a>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Configuración de Reglas</title>
+    <title>Reglas</title>
     <style>
         body {
             font-family: 'Segoe UI', sans-serif;
@@ -67,7 +67,7 @@
     </style>
 </head>
 <body>
-    <h2>Configuración de Reglas</h2>
+    <h2>Reglas</h2>
     <p>Para reglas de medición usa "*" en <em>Texto del usuario</em> y define la fórmula en <em>Cálculo</em> con variables como <code>medida</code>, <code>p1</code> o <code>p2</code>. Opcionalmente indica un <em>Handler</em> para delegar el cálculo a código externo.</p>
 
     <form method="POST" enctype="multipart/form-data">


### PR DESCRIPTION
## Summary
- create new reglas.html with rule management form and media toggle for specific types
- add /reglas route reusing rule logic and update deletion redirect
- update navigation to point to /reglas and refine media toggle in existing template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d19ed98788323a8d127bc11da4161