### PR TITLE
Align bot messages to the right in chat template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -175,7 +175,7 @@
       word-wrap:break-word; box-shadow:0 2px 4px rgba(0,0,0,0.1);
     }
     .cliente { align-self:flex-start; background:var(--bubble-user); color:var(--text-main); }
-    .bot     { align-self:flex-start; background:var(--bubble-bot);  color:var(--text-main); }
+    .bot     { align-self:flex-end;   background:var(--bubble-bot);  color:var(--text-main); }
     .asesor  { align-self:flex-end;   background:var(--bubble-asesor); color:var(--text-main); font-weight:bold; }
 
     /* Input area */


### PR DESCRIPTION
## Summary
- align bot message bubbles to the right in `index.html`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d20c029648323ab6aa4a51fcd5af3