### PR TITLE
Expose link preview fields in chat retrieval

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -84,14 +84,15 @@ def get_chat(numero):
             conn.close()
             return jsonify({'error': 'No autorizado'}), 403
     c.execute("""
-      SELECT mensaje, tipo, media_url, timestamp
+      SELECT mensaje, tipo, media_url, timestamp,
+             link_url, link_title, link_body, link_thumb
       FROM mensajes
       WHERE numero = %s
       ORDER BY timestamp
     """, (numero,))
     mensajes = c.fetchall()
     conn.close()
-    return jsonify({'mensajes': mensajes})
+    return jsonify({'mensajes': [list(m) for m in mensajes]})
 
 @chat_bp.route('/send_message', methods=['POST'])
 def send_message():

--- a/templates/index.html
+++ b/templates/index.html
@@ -375,7 +375,7 @@
               chatBoxEl.innerHTML = ''; lastCount = 0;
             }
             for (let i=lastCount; i<total; i++){
-              const [txt, tipo, url, ts] = msgs[i];
+              const [txt, tipo, url, ts, linkUrl, linkTitle, linkBody, linkThumb] = msgs[i];
               const div = document.createElement('div');
               // map tipo a bubble class
               let bubble = 'cliente';


### PR DESCRIPTION
## Summary
- Expand `/get_chat` query to return link preview details (URL, title, body, thumbnail)
- Deserialize these additional link fields on the frontend

## Testing
- `python -m py_compile routes/chat_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2eb42a8c8323865183be7df6fb6b