### PR TITLE
Track chat session state in backend and UI

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -40,10 +40,10 @@ def register_external(name):
     return decorator
 
 
-def set_user_step(numero, step):
+def set_user_step(numero, step, estado='espera_usuario'):
     """Actualiza el paso en memoria y en la tabla chat_state."""
     user_steps[numero] = step
-    update_chat_state(numero, step)
+    update_chat_state(numero, step, estado)
 
 os.makedirs(Config.UPLOAD_FOLDER, exist_ok=True)
 
@@ -338,4 +338,5 @@ def webhook():
                 set_user_step(from_number, next_step.strip().lower() if next_step else '')
             else:
                 enviar_mensaje(from_number, "No entendí tu respuesta, intenta de nuevo.")
+                update_chat_state(from_number, step, 'sin_regla')
     return jsonify({'status':'received'}), 200

--- a/templates/index.html
+++ b/templates/index.html
@@ -115,6 +115,9 @@
     #chatList li.active {
       background:var(--accent); color:var(--text-light);
     }
+    .estado-sin_regla { border-left:4px solid orange; }
+    .estado-espera_usuario { border-left:4px solid green; }
+    .estado-asesor { border-left:4px solid yellow; }
 
     /* Chat window */
     .chatWindow { flex:1; display:flex; flex-direction:column; }
@@ -325,6 +328,7 @@
               }
               const li = document.createElement('li');
               li.textContent = c.alias ? `${c.alias} (${c.numero})` : c.numero;
+              if (c.estado) li.classList.add('estado-' + c.estado);
 
               // Al hacer clic, seleccionar el chat
               li.onclick = () => selectChat(c.numero, li);


### PR DESCRIPTION
## Summary
- store `estado` in `chat_state` table and update records with new statuses
- expose chat status in `/get_chat_list` and highlight chats based on state
- mark chats as under advisor control when staff send messages or media

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d371a445483239ef7178cc2702cc3