### PR TITLE
Show role initial badge in chat list

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -104,6 +104,7 @@
       flex:1; overflow-y:auto; list-style:none;
     }
     #chatList li {
+      position:relative;
       padding:12px; margin-bottom:6px; border-radius:12px;
       cursor:pointer; transition:background 0.3s,transform 0.2s;
       color:var(--text-main);
@@ -114,6 +115,17 @@
     }
     #chatList li.active {
       background:var(--accent); color:var(--text-light);
+    }
+    #chatList li .badge {
+      position:absolute;
+      top:-6px; right:-6px;
+      width:20px; height:20px;
+      border-radius:50%;
+      background:var(--accent);
+      color:var(--text-light);
+      font-size:12px;
+      display:flex; align-items:center; justify-content:center;
+      pointer-events:none;
     }
     .estado-sin_regla { border-left:4px solid orange; }
     .estado-espera_usuario { border-left:4px solid green; }
@@ -329,6 +341,14 @@
               const li = document.createElement('li');
               li.textContent = c.alias ? `${c.alias} (${c.numero})` : c.numero;
               if (c.estado) li.classList.add('estado-' + c.estado);
+
+              // Badge con inicial del rol
+              if (c.inicial_rol) {
+                const badge = document.createElement('span');
+                badge.className = 'badge';
+                badge.textContent = c.inicial_rol;
+                li.appendChild(badge);
+              }
 
               // Al hacer clic, seleccionar el chat
               li.onclick = () => selectChat(c.numero, li);


### PR DESCRIPTION
## Summary
- join roles table when retrieving chat list to derive role initial
- display role initial badge beside each chat entry
- style chat list items with positioned role badge

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d3898f038832399c22dced047e752