### PR TITLE
Usar background-color en estados del chat

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -127,9 +127,9 @@
       display:flex; align-items:center; justify-content:center;
       pointer-events:none;
     }
-    .estado-sin_regla { border-left:4px solid orange; }
-    .estado-espera_usuario { border-left:4px solid green; }
-    .estado-asesor { border-left:4px solid yellow; }
+    .estado-sin_regla { background-color: orange; color: var(--text-light); }
+    .estado-espera_usuario { background-color: green; color: var(--text-light); }
+    .estado-asesor { background-color: yellow; color: var(--text-main); }
 
     /* Chat window */
     .chatWindow { flex:1; display:flex; flex-direction:column; }


### PR DESCRIPTION
## Summary
- Reemplaza los estilos de borde por colores de fondo para los estados de chat

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d3a875e6c8323ac39da0e7cc70d7b