### PR TITLE
Adjust chat badge alignment on index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -108,6 +108,7 @@
       padding:12px; margin-bottom:6px; border-radius:12px;
       cursor:pointer; transition:background 0.3s,transform 0.2s;
       color:var(--text-main);
+      padding-left:24px;
     }
     #chatList li:hover {
       background:var(--accent-hover); color:var(--text-light);
@@ -118,7 +119,9 @@
     }
     #chatList li .badge {
       position:absolute;
-      top:-6px; right:-6px;
+      left:-10px;
+      top:50%;
+      transform:translateY(-50%);
       width:20px; height:20px;
       border-radius:50%;
       background:var(--accent);


### PR DESCRIPTION
## Summary
- Position chat list badge on the left and center it vertically
- Increase left padding of chat items to avoid overlap with text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d3b63c81483239ea5fdc615fb1228