### PR TITLE
Store WhatsApp message identifiers

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -85,7 +85,8 @@ def get_chat(numero):
             return jsonify({'error': 'No autorizado'}), 403
     c.execute("""
       SELECT mensaje, tipo, media_url, timestamp,
-             link_url, link_title, link_body, link_thumb
+             link_url, link_title, link_body, link_thumb,
+             wa_id, reply_to_wa_id
       FROM mensajes
       WHERE numero = %s
       ORDER BY timestamp

--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -129,6 +129,10 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
 
     resp = requests.post(url, headers=headers, json=data)
     print(f"[WA API] {resp.status_code} — {resp.text}")
+    try:
+        wa_id = resp.json().get("messages", [{}])[0].get("id")
+    except Exception:
+        wa_id = None
     tipo_db = tipo
     if tipo_respuesta in {"image", "audio", "video", "document"} and "_" not in tipo:
         tipo_db = f"{tipo}_{tipo_respuesta}"
@@ -138,6 +142,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             numero,
             mensaje,
             tipo_db,
+            wa_id=wa_id,
             media_id=None,
             media_url=video_obj.get("link")
         )
@@ -147,6 +152,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             numero,
             mensaje,
             tipo_db,
+            wa_id=wa_id,
             media_id=None,
             media_url=audio_obj.get("link")
         )
@@ -155,6 +161,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             numero,
             mensaje,
             tipo_db,
+            wa_id=wa_id,
             media_id=None,
             media_url=opciones
         )


### PR DESCRIPTION
## Summary
- capture and persist WhatsApp message IDs and references with new `wa_id` and `reply_to_wa_id` columns
- record these identifiers when sending or receiving messages and expose them via `/get_chat/<numero>`

## Testing
- `python -m py_compile services/db.py services/whatsapp_api.py routes/webhook.py routes/chat_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e151534248323829de2ea5bea3dfa