### PR TITLE
Track and render WhatsApp reply messages

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -84,12 +84,14 @@ def get_chat(numero):
             conn.close()
             return jsonify({'error': 'No autorizado'}), 403
     c.execute("""
-      SELECT mensaje, tipo, media_url, timestamp,
-             link_url, link_title, link_body, link_thumb,
-             wa_id, reply_to_wa_id
-      FROM mensajes
-      WHERE numero = %s
-      ORDER BY timestamp
+      SELECT m.mensaje, m.tipo, m.media_url, m.timestamp,
+             m.link_url, m.link_title, m.link_body, m.link_thumb,
+             m.wa_id, m.reply_to_wa_id,
+             r.mensaje AS reply_text, r.tipo AS reply_tipo, r.media_url AS reply_media_url
+      FROM mensajes m
+      LEFT JOIN mensajes r ON r.wa_id = m.reply_to_wa_id
+      WHERE m.numero = %s
+      ORDER BY m.timestamp
     """, (numero,))
     mensajes = c.fetchall()
     conn.close()

--- a/templates/index.html
+++ b/templates/index.html
@@ -196,6 +196,11 @@
       max-width:70%; padding:10px 14px; border-radius:16px;
       word-wrap:break-word; box-shadow:0 2px 4px rgba(0,0,0,0.1);
     }
+    .reply {
+      font-size:0.85em; opacity:0.8;
+      border-left:3px solid var(--accent);
+      padding-left:6px; margin-bottom:4px;
+    }
     .cliente { align-self:flex-start; background:var(--bubble-user); color:var(--text-main); }
     .bot     { align-self:flex-end;   background:var(--bubble-bot);  color:var(--text-main); }
     .asesor  { align-self:flex-end;   background:var(--bubble-asesor); color:var(--text-main); font-weight:bold; }
@@ -406,13 +411,30 @@
               chatBoxEl.innerHTML = ''; lastCount = 0;
             }
             for (let i=lastCount; i<total; i++){
-              const [txt, tipo, url, ts, linkUrl, linkTitle, linkBody, linkThumb] = msgs[i];
+              const [txt, tipo, url, ts, linkUrl, linkTitle, linkBody, linkThumb, waId, replyWaId, replyText, replyTipo, replyUrl] = msgs[i];
               const div = document.createElement('div');
               // map tipo a bubble class
               let bubble = 'cliente';
               if (tipo.startsWith('bot'))    bubble='bot';
               if (tipo.startsWith('asesor')) bubble='asesor';
               div.className = `bubble ${bubble} message`;
+
+              if (replyWaId) {
+                const replyDiv = document.createElement('div');
+                replyDiv.className = 'reply';
+                if (replyTipo && replyTipo.endsWith('_image') && replyUrl) {
+                  const img = document.createElement('img');
+                  img.src = replyUrl;
+                  img.style.maxWidth = '100px';
+                  replyDiv.appendChild(img);
+                }
+                if (replyText) {
+                  const p = document.createElement('p');
+                  p.textContent = replyText;
+                  replyDiv.appendChild(p);
+                }
+                div.appendChild(replyDiv);
+              }
 
               // insertar media o texto
               if (tipo === 'referral' && linkUrl) {


### PR DESCRIPTION
## Summary
- Handle multiple incoming messages and capture WhatsApp message IDs and reply references in the webhook, storing them with each saved message
- Resolve replies in chat retrieval by joining messages on their WhatsApp IDs
- Display referenced message snippets in the front-end with basic styling for replies

## Testing
- `python -m py_compile routes/webhook.py routes/chat_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_689e23fdc378832386a9f710cc6597f6