### PR TITLE
Add reply support in chat UI and API

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -107,6 +107,7 @@ def send_message():
     texto  = data.get('mensaje')
     tipo_respuesta = data.get('tipo_respuesta', 'texto')
     opciones = data.get('opciones')
+    reply_to_wa_id = data.get('reply_to_wa_id')
 
     conn = get_connection()
     c    = conn.cursor()
@@ -128,7 +129,14 @@ def send_message():
         return jsonify({'error': 'No autorizado'}), 403
 
     # Envía por la API y guarda internamente
-    enviar_mensaje(numero, texto, tipo='asesor', tipo_respuesta=tipo_respuesta, opciones=opciones)
+    enviar_mensaje(
+        numero,
+        texto,
+        tipo='asesor',
+        tipo_respuesta=tipo_respuesta,
+        opciones=opciones,
+        reply_to_wa_id=reply_to_wa_id,
+    )
     row = get_chat_state(numero)
     step = row[0] if row else ''
     update_chat_state(numero, step, 'asesor')

--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -9,7 +9,7 @@ from services.db import guardar_mensaje
 TOKEN    = Config.META_TOKEN
 PHONE_ID = Config.PHONE_NUMBER_ID
 
-def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones=None):
+def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones=None, reply_to_wa_id=None):
     url = f"https://graph.facebook.com/v19.0/{PHONE_ID}/messages"
     headers = {
         "Authorization": f"Bearer {TOKEN}",
@@ -127,6 +127,9 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             "text": {"body": mensaje}
         }
 
+    if reply_to_wa_id:
+        data["context"] = {"message_id": reply_to_wa_id}
+
     resp = requests.post(url, headers=headers, json=data)
     print(f"[WA API] {resp.status_code} — {resp.text}")
     try:
@@ -143,6 +146,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             mensaje,
             tipo_db,
             wa_id=wa_id,
+            reply_to_wa_id=reply_to_wa_id,
             media_id=None,
             media_url=video_obj.get("link")
         )
@@ -153,6 +157,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             mensaje,
             tipo_db,
             wa_id=wa_id,
+            reply_to_wa_id=reply_to_wa_id,
             media_id=None,
             media_url=audio_obj.get("link")
         )
@@ -162,6 +167,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             mensaje,
             tipo_db,
             wa_id=wa_id,
+            reply_to_wa_id=reply_to_wa_id,
             media_id=None,
             media_url=opciones
         )

--- a/templates/index.html
+++ b/templates/index.html
@@ -201,6 +201,33 @@
       border-left:3px solid var(--accent);
       padding-left:6px; margin-bottom:4px;
     }
+    .context-menu {
+      position:absolute;
+      background:var(--text-light);
+      border:1px solid #ccc;
+      border-radius:4px;
+      box-shadow:0 2px 6px rgba(0,0,0,0.1);
+      display:none;
+      z-index:20;
+    }
+    .context-menu.show { display:block; }
+    .context-menu div {
+      padding:8px 12px; cursor:pointer;
+    }
+    .context-menu div:hover {
+      background:var(--accent); color:var(--text-light);
+    }
+    .reply-preview {
+      margin:8px 12px; padding:4px 8px;
+      border-left:3px solid var(--accent);
+      background:var(--text-light);
+      display:none;
+    }
+    .reply-preview img,
+    .reply-preview video,
+    .reply-preview audio {
+      max-width:100px; display:block; margin-bottom:4px;
+    }
     .cliente { align-self:flex-start; background:var(--bubble-user); color:var(--text-main); }
     .bot     { align-self:flex-end;   background:var(--bubble-bot);  color:var(--text-main); }
     .asesor  { align-self:flex-end;   background:var(--bubble-asesor); color:var(--text-main); font-weight:bold; }
@@ -302,32 +329,69 @@
     <div class="chatWindow">
       <div id="botonera"></div>
       <div id="chatBox"></div>
+      <div id="replyPreview" class="reply-preview"></div>
       <div class="inputArea">
         <button id="attachBtn">+</button>
-        <div id="attachMenu" class="attach-menu">
-          <div id="attachImage" class="attach-item" title="Enviar imagen">📷</div>
-          <div id="attachAudio" class="attach-item" title="Enviar audio">🎤</div>
-          <div id="attachVideo" class="attach-item" title="Enviar video">🎥</div>
-        </div>
-        <input id="messageInput" type="text" placeholder="Escribe un mensaje…">
-        <button id="sendBtn">Enviar</button>
-        <input id="imageInput" type="file" accept="image/*" style="display:none;">
-        <input id="audioInput" type="file" accept="audio/*" style="display:none;">
-        <input id="videoInput" type="file" accept="video/*" style="display:none;">
+      <div id="attachMenu" class="attach-menu">
+        <div id="attachImage" class="attach-item" title="Enviar imagen">📷</div>
+        <div id="attachAudio" class="attach-item" title="Enviar audio">🎤</div>
+        <div id="attachVideo" class="attach-item" title="Enviar video">🎥</div>
       </div>
+      <input id="messageInput" type="text" placeholder="Escribe un mensaje…">
+      <button id="sendBtn">Enviar</button>
+      <input id="imageInput" type="file" accept="image/*" style="display:none;">
+      <input id="audioInput" type="file" accept="audio/*" style="display:none;">
+      <input id="videoInput" type="file" accept="video/*" style="display:none;">
     </div>
   </div>
+</div>
+
+  <div id="contextMenu" class="context-menu"><div id="replyAction">Responder</div></div>
 
   <div class="role-indicator">{{ rol }}</div>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      let currentChat = null, autoRefresh = null, todosChats = [], lastCount = 0;
+      let currentChat = null, autoRefresh = null, todosChats = [], lastCount = 0, replyTo = null;
+      let selectedBubble = null;
       const chatListEl = document.getElementById('chatList');
       const chatBoxEl  = document.getElementById('chatBox');
       const botoneraEl = document.getElementById('botonera');
+      const replyPreviewEl = document.getElementById('replyPreview');
+      const contextMenu = document.getElementById('contextMenu');
+      const replyAction = document.getElementById('replyAction');
       const userRole   = "{{ rol }}";
       const userRoleId = {{ role_id | tojson }};
+
+      document.addEventListener('click', () => contextMenu.classList.remove('show'));
+
+      replyAction.onclick = () => {
+        if (!selectedBubble) return;
+        replyTo = selectedBubble.dataset.waId;
+        replyPreviewEl.innerHTML = '';
+        const tipo = selectedBubble.dataset.tipo || '';
+        const url  = selectedBubble.dataset.url;
+        const text = selectedBubble.dataset.text;
+        if (url && tipo.endsWith('_image')) {
+          const img = document.createElement('img');
+          img.src = url; replyPreviewEl.appendChild(img);
+        } else if (url && tipo.includes('audio')) {
+          const a = document.createElement('audio'); a.controls=true; a.src=url; replyPreviewEl.appendChild(a);
+        } else if (url && tipo.includes('video')) {
+          const v = document.createElement('video'); v.controls=true; v.src=url; replyPreviewEl.appendChild(v);
+        }
+        if (text) {
+          const p = document.createElement('p'); p.textContent = text; replyPreviewEl.appendChild(p);
+        }
+        replyPreviewEl.style.display = 'block';
+        contextMenu.classList.remove('show');
+      };
+
+      replyPreviewEl.onclick = () => {
+        replyTo = null;
+        replyPreviewEl.style.display = 'none';
+        replyPreviewEl.innerHTML = '';
+      };
 
       // Mostrar u ocultar menú settings
       const settingsBtn = document.getElementById('settingsBtn');
@@ -427,6 +491,13 @@
                   img.src = replyUrl;
                   img.style.maxWidth = '100px';
                   replyDiv.appendChild(img);
+                } else if (replyTipo && replyTipo.includes('audio') && replyUrl) {
+                  const a = document.createElement('audio');
+                  a.controls = true; a.src = replyUrl; replyDiv.appendChild(a);
+                } else if (replyTipo && replyTipo.includes('video') && replyUrl) {
+                  const v = document.createElement('video');
+                  v.controls = true; v.src = replyUrl; v.style.maxWidth = '100px';
+                  replyDiv.appendChild(v);
                 }
                 if (replyText) {
                   const p = document.createElement('p');
@@ -481,6 +552,21 @@
                 div.appendChild(timeSpan);
               }
 
+              if (waId) {
+                div.dataset.waId = waId;
+                if (txt) div.dataset.text = txt;
+                if (url) div.dataset.url = url;
+                div.dataset.tipo = tipo;
+                div.addEventListener('contextmenu', e => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  selectedBubble = div;
+                  contextMenu.style.top = e.pageY + 'px';
+                  contextMenu.style.left = e.pageX + 'px';
+                  contextMenu.classList.add('show');
+                });
+              }
+
               chatBoxEl.appendChild(div);
             }
             lastCount = total;
@@ -506,9 +592,15 @@
                     numero: currentChat,
                     mensaje: b.mensaje,
                     tipo_respuesta: b.tipo,
-                    opciones: b.media_url
+                    opciones: b.media_url,
+                    reply_to_wa_id: replyTo
                   })
-                }).then(()=>{ loadMessages(); fetchChatList(); });
+                }).then(()=>{
+                  replyTo=null;
+                  replyPreviewEl.style.display='none';
+                  replyPreviewEl.innerHTML='';
+                  loadMessages(); fetchChatList();
+                });
               };
               botoneraEl.appendChild(btn);
             });
@@ -523,9 +615,13 @@
         fetch('/send_message',{
           method:'POST',
           headers:{'Content-Type':'application/json'},
-          body:JSON.stringify({numero:currentChat,mensaje:txt})
+          body:JSON.stringify({numero:currentChat,mensaje:txt,reply_to_wa_id:replyTo})
         }).then(()=>{
-          inp.value=''; loadMessages(); fetchChatList();
+          inp.value='';
+          replyTo=null;
+          replyPreviewEl.style.display='none';
+          replyPreviewEl.innerHTML='';
+          loadMessages(); fetchChatList();
         });
       };
 


### PR DESCRIPTION
## Summary
- allow replying to specific messages by propagating `reply_to_wa_id` through `send_message`
- include reply context when sending messages to WhatsApp API and store reference in DB
- add UI context menu and preview to reply to messages and show quoted media or text

## Testing
- `python -m py_compile routes/chat_routes.py services/whatsapp_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689e356ff5448323b4e1c43fda38ba31