### PR TITLE
Add Streamlit dashboard tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from routes.chat_routes import chat_bp
 from routes.configuracion import config_bp
 from routes.roles_routes import roles_bp
 from routes.webhook import webhook_bp
+from routes.tablero_routes import tablero_bp
 
 # Carga .env y crea la app
 load_dotenv()
@@ -25,6 +26,7 @@ app.register_blueprint(chat_bp)
 app.register_blueprint(config_bp)
 app.register_blueprint(roles_bp)
 app.register_blueprint(webhook_bp)
+app.register_blueprint(tablero_bp)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mysql-connector-python
 vosk
 ffmpeg-python
 concurrent-futures; python_version < "3.2"
+streamlit

--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, render_template, session, redirect, url_for
+
+
+tablero_bp = Blueprint('tablero', __name__)
+
+
+@tablero_bp.route('/tablero')
+def tablero():
+    """Renderiza la página del tablero con gráficos de Streamlit."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+    return render_template('tablero.html')

--- a/scripts/tablero.py
+++ b/scripts/tablero.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import streamlit as st
+
+from services.db import get_connection
+
+
+def cargar_datos():
+    """Obtiene los mensajes y calcula la cantidad de palabras por chat."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT numero, mensaje FROM mensajes")
+    datos = cur.fetchall()
+    conn.close()
+
+    df = pd.DataFrame(datos, columns=["numero", "mensaje"])
+    df["palabras"] = df["mensaje"].fillna("").apply(lambda x: len(x.split()))
+    return df.groupby("numero")['palabras'].sum().reset_index()
+
+
+def main():
+    st.title("Número de palabras por chat")
+    df = cargar_datos()
+    st.bar_chart(df.set_index('numero'))
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/index.html
+++ b/templates/index.html
@@ -319,6 +319,7 @@
         {% if session.get('roles') and 'admin' in session['roles'] %}
         <a href="{{ url_for('roles.roles') }}">Roles</a>
         {% endif %}
+        <a href="{{ url_for('tablero.tablero') }}">Tablero</a>
         <a href="{{ url_for('auth.logout') }}">Cerrar sesión</a>
       </div>
       <input id="buscador" type="text" placeholder="Buscar número…">

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Tablero</title>
+    <style>
+        body { margin: 0; font-family: 'Segoe UI', sans-serif; }
+        iframe { border: none; width: 100%; height: 100vh; }
+        .back-btn { position: absolute; top: 20px; right: 20px; }
+        .back-btn button {
+            background-color: #3498db;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            padding: 10px 20px;
+            font-size: 14px;
+            cursor: pointer;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+    </style>
+</head>
+<body>
+    <div class="back-btn">
+        <a href="{{ url_for('chat.index') }}"><button>Volver al inicio</button></a>
+    </div>
+    <iframe src="http://localhost:8501"></iframe>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Tablero blueprint and template with Streamlit iframe
- include Streamlit word-count chart script
- link Tablero tab in chat settings and update requirements

## Testing
- `python -m py_compile app.py routes/tablero_routes.py scripts/tablero.py`


------
https://chatgpt.com/codex/tasks/task_e_689e8194c50c8323a070b5dcd4a4a957