### PR TITLE
feat: add Streamlit URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ Para agregar un nuevo comando:
 
 La función `handle_global_command` es llamada desde `routes/webhook.py` y detiene el
 procesamiento normal cuando un comando es reconocido.
+
+## Configuración de Streamlit
+
+Para apuntar a una URL de Streamlit distinta a la predeterminada, define la variable de entorno `STREAMLIT_URL` durante el despliegue.
+Si no se establece, la aplicación usará `http://localhost:8501`.

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class Config:
     VERIFY_TOKEN = os.getenv('VERIFY_TOKEN')
     DB_PATH = 'database.db'
     SESSION_TIMEOUT = 600
+    STREAMLIT_URL = os.getenv("STREAMLIT_URL", "http://localhost:8501")
 
     MAX_TRANSCRIPTION_DURATION_MS = int(os.getenv('MAX_TRANSCRIPTION_DURATION_MS', 60000))
     TRANSCRIPTION_MAX_AVG_TIME_SEC = float(os.getenv('TRANSCRIPTION_MAX_AVG_TIME_SEC', 10))


### PR DESCRIPTION
## Summary
- configure Streamlit URL via STREAMLIT_URL env variable
- document STREAMLIT_URL usage for deployments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e888125c48323917b34da5e6a9253