### PR TITLE
Expose Streamlit dashboard URL via template

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, session, redirect, url_for
+from flask import Blueprint, render_template, session, redirect, url_for, current_app
 
 
 tablero_bp = Blueprint('tablero', __name__)
@@ -9,4 +9,4 @@ def tablero():
     """Renderiza la página del tablero con gráficos de Streamlit."""
     if "user" not in session:
         return redirect(url_for('auth.login'))
-    return render_template('tablero.html')
+    return render_template('tablero.html', streamlit_url=current_app.config["STREAMLIT_URL"])

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -23,6 +23,6 @@
     <div class="back-btn">
         <a href="{{ url_for('chat.index') }}"><button>Volver al inicio</button></a>
     </div>
-    <iframe src="http://localhost:8501"></iframe>
+    <iframe src="{{ streamlit_url }}"></iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Pass `STREAMLIT_URL` from Flask config to the tablero template
- Use `streamlit_url` variable in tablero HTML to embed Streamlit dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e89411a54832389d6d9631aa5d9cd