### PR TITLE
Fix Streamlit dashboard tab

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+headless = true
+enableCORS = false
+enableXsrfProtection = false

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn app:app --bind 0.0.0.0:$PORT --workers 4
-streamlit: streamlit run scripts/tablero.py --server.address 0.0.0.0
+streamlit: streamlit run scripts/tablero.py --server.address 0.0.0.0 --server.enableCORS=false --server.enableXsrfProtection=false


### PR DESCRIPTION
## Summary
- allow embedding the Streamlit dashboard by disabling CORS and XSRF protection
- configure Streamlit to run headlessly via config file

## Testing
- `python -m py_compile routes/tablero_routes.py scripts/tablero.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6230224c8323a6b0cf0e4a9eab57