### PR TITLE
Load configuration object into Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from routes.tablero_routes import tablero_bp
 load_dotenv()
 os.makedirs(Config.UPLOAD_FOLDER, exist_ok=True)
 app = Flask(__name__)
+app.config.from_object(Config)
 app.secret_key = os.getenv('SECRET_KEY')
 
 # --- Inicializa la base de datos inmediatamente, al importar app.py ---


### PR DESCRIPTION
## Summary
- Load Flask configuration from `Config` so values like `STREAMLIT_URL` are available via `app.config`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f646049d883239aac31f801a13388