### PR TITLE
Add dashboard JSON endpoint and Chart.js template

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, render_template, session, redirect, url_for, current_app
+from flask import Blueprint, render_template, session, redirect, url_for, jsonify
+
+from services.db import get_connection
 
 
 tablero_bp = Blueprint('tablero', __name__)
@@ -6,8 +8,28 @@ tablero_bp = Blueprint('tablero', __name__)
 
 @tablero_bp.route('/tablero')
 def tablero():
-    """Renderiza la página del tablero con gráficos de Streamlit."""
+    """Renderiza la página del tablero con gráficos de Chart.js."""
     if "user" not in session:
         return redirect(url_for('auth.login'))
-    streamlit_url = current_app.config["STREAMLIT_URL"]
-    return render_template('tablero.html', streamlit_url=streamlit_url)
+    return render_template('tablero.html')
+
+
+@tablero_bp.route('/datos_tablero')
+def datos_tablero():
+    """Devuelve métricas del tablero en formato JSON."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT numero, mensaje FROM mensajes")
+    rows = cur.fetchall()
+    conn.close()
+
+    metrics = {}
+    for numero, mensaje in rows:
+        palabras = len((mensaje or "").split())
+        metrics[numero] = metrics.get(numero, 0) + palabras
+
+    data = [{"numero": num, "palabras": count} for num, count in metrics.items()]
+    return jsonify(data)

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <title>Tablero</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body { margin: 0; font-family: 'Segoe UI', sans-serif; }
-        iframe { border: none; width: 100%; height: 100vh; }
         .back-btn { position: absolute; top: 20px; right: 20px; }
         .back-btn button {
             background-color: #3498db;
@@ -17,13 +17,40 @@
             cursor: pointer;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
+        #grafico { max-width: 800px; margin: 80px auto; }
     </style>
 </head>
 <body>
     <div class="back-btn">
         <a href="{{ url_for('chat.index') }}"><button>Volver al inicio</button></a>
     </div>
-    <!-- Embed Streamlit dashboard -->
-    <iframe src="{{ streamlit_url }}"></iframe>
+    <canvas id="grafico"></canvas>
+    <script>
+        fetch("{{ url_for('tablero.datos_tablero') }}")
+            .then(response => response.json())
+            .then(data => {
+                const labels = data.map(item => item.numero);
+                const values = data.map(item => item.palabras);
+                const ctx = document.getElementById('grafico').getContext('2d');
+                new Chart(ctx, {
+                    type: 'bar',
+                    data: {
+                        labels: labels,
+                        datasets: [{
+                            label: 'Palabras por chat',
+                            data: values,
+                            backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                            borderColor: 'rgba(54, 162, 235, 1)',
+                            borderWidth: 1
+                        }]
+                    },
+                    options: {
+                        scales: {
+                            y: { beginAtZero: true }
+                        }
+                    }
+                });
+            });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `/datos_tablero` endpoint that aggregates words per chat and returns metrics as JSON
- Replace Streamlit iframe with Chart.js dashboard consuming the new JSON endpoint

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f6a3c15088323996bbdf736d36370