### PR TITLE
Add top numbers endpoint and chart

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -83,3 +83,31 @@ def datos_roles():
 
     data = [{"rol": rol, "mensajes": count} for rol, count in rows]
     return jsonify(data)
+
+
+@tablero_bp.route('/datos_top_numeros')
+def datos_top_numeros():
+    """Devuelve los números con más mensajes de clientes."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    limite = request.args.get('limit', 5, type=int)
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT numero, COUNT(*) AS total
+          FROM mensajes
+         WHERE tipo LIKE 'cliente%'
+         GROUP BY numero
+         ORDER BY total DESC
+         LIMIT ?
+        """,
+        (limite,),
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    data = [{"numero": numero, "mensajes": total} for numero, total in rows]
+    return jsonify(data)

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -17,7 +17,7 @@
             cursor: pointer;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
-        #grafico, #graficoPalabras, #graficoRoles { max-width: 800px; margin: 80px auto; }
+        #grafico, #graficoPalabras, #graficoRoles, #graficoTopNumeros { max-width: 800px; margin: 80px auto; }
     </style>
 </head>
 <body>
@@ -25,6 +25,7 @@
         <a href="{{ url_for('chat.index') }}"><button>Volver al inicio</button></a>
     </div>
     <canvas id="grafico"></canvas>
+    <canvas id="graficoTopNumeros"></canvas>
     <canvas id="graficoPalabras"></canvas>
     <canvas id="graficoRoles"></canvas>
     <script>
@@ -49,6 +50,34 @@
                     options: {
                         scales: {
                             y: { beginAtZero: true }
+                        }
+                    }
+                });
+            });
+    </script>
+    <script>
+        fetch("{{ url_for('tablero.datos_top_numeros') }}")
+            .then(response => response.json())
+            .then(data => {
+                const labels = data.map(item => item.numero);
+                const values = data.map(item => item.mensajes);
+                const ctx = document.getElementById('graficoTopNumeros').getContext('2d');
+                new Chart(ctx, {
+                    type: 'bar',
+                    data: {
+                        labels: labels,
+                        datasets: [{
+                            label: 'Mensajes por número',
+                            data: values,
+                            backgroundColor: 'rgba(75, 192, 192, 0.5)',
+                            borderColor: 'rgba(75, 192, 192, 1)',
+                            borderWidth: 1
+                        }]
+                    },
+                    options: {
+                        indexAxis: 'y',
+                        scales: {
+                            x: { beginAtZero: true }
                         }
                     }
                 });


### PR DESCRIPTION
## Summary
- add `/datos_top_numeros` endpoint to return top client numbers and message counts
- render horizontal bar chart in tablero for numbers with most messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7a5ab1108323af5f2f92937e64d0