### PR TITLE
feat: refine roles query and rename roles chart canvas

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -73,11 +73,11 @@ def datos_roles():
     cur.execute(
         """
         SELECT COALESCE(r.keyword, r.name) AS rol, COUNT(*) AS mensajes
-          FROM mensajes m
-          INNER JOIN chat_roles cr ON m.numero = cr.numero
-          INNER JOIN roles r ON cr.role_id = r.id
+          FROM mensajes AS m
+          JOIN chat_roles AS cr ON m.numero = cr.numero
+          JOIN roles AS r ON cr.role_id = r.id
          WHERE m.tipo LIKE 'cliente%'
-         GROUP BY r.keyword, r.name
+         GROUP BY rol
         """
     )
     rows = cur.fetchall()

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -17,7 +17,7 @@
             cursor: pointer;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
-        #grafico, #grafico_palabras, #graficoRoles, #graficoTopNumeros, #graficoTotales { max-width: 800px; margin: 80px auto; }
+        #grafico, #grafico_palabras, #grafico_roles, #graficoTopNumeros, #graficoTotales { max-width: 800px; margin: 80px auto; }
     </style>
 </head>
 <body>
@@ -28,7 +28,7 @@
     <canvas id="grafico"></canvas>
     <canvas id="graficoTopNumeros"></canvas>
     <canvas id="grafico_palabras"></canvas>
-    <canvas id="graficoRoles"></canvas>
+    <canvas id="grafico_roles"></canvas>
     <script>
         fetch("{{ url_for('tablero.datos_totales') }}")
             .then(response => response.json())
@@ -142,7 +142,7 @@
             .then(data => {
                 const labels = data.map(item => item.rol);
                 const values = data.map(item => item.mensajes);
-                const ctx = document.getElementById('graficoRoles').getContext('2d');
+                const ctx = document.getElementById('grafico_roles').getContext('2d');
                 const colors = ['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40'];
                 new Chart(ctx, {
                     type: 'pie',


### PR DESCRIPTION
## Summary
- Refactor `/datos_roles` to group by role alias when aggregating client messages
- Update dashboard template with `grafico_roles` canvas and script for role chart

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7e56a1948323bfd783c87d86ae2d