### PR TITLE
feat: make chat layout responsive

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -172,3 +172,17 @@ button:active:after {
 .attach-menu {
   transition: opacity 0.2s, transform 0.2s;
 }
+
+@media (max-width: 768px) {
+    .container {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+    }
+
+    .chatWindow {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- make container responsive with mobile media query
- expand sidebar and chat window to full width on small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f8314fe488323b5812ed6bc4fe01a