### PR TITLE
Ignore user media directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 *.log
 __pycache__/
 *.pyc
+
+# Medios generados por los usuarios
+static/uploads/
+uploads/
+media/

--- a/README.md
+++ b/README.md
@@ -127,3 +127,7 @@ procesamiento normal cuando un comando es reconocido.
 
 Para apuntar a una URL de Streamlit distinta a la predeterminada, define la variable de entorno `STREAMLIT_URL` durante el despliegue.
 Si no se establece, la aplicación usará `http://localhost:8501`.
+
+## Almacenamiento de medios subidos por el usuario
+
+Los archivos generados por los usuarios (por ejemplo, en `static/uploads/` u otras carpetas de medios) no deben versionarse en Git. Durante los despliegues, mantén estas rutas en un volumen persistente o en un almacenamiento externo para evitar su borrado accidental.


### PR DESCRIPTION
## Summary
- ignore user-generated media folders such as static/uploads
- document persisting uploaded media outside the repo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50f8c3b8c8323ba0f7da490cc102a