### PR TITLE
Improve global command handling with text normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Para agregar un nuevo comando:
 
 1. Edita `services/global_commands.py`.
 2. Crea una función que reciba el número del usuario y realice la acción deseada.
-3. Registra la función en el diccionario `GLOBAL_COMMANDS` asociándola a la palabra clave.
+3. Registra la función en el diccionario `GLOBAL_COMMANDS` usando la palabra clave normalizada con `normalize_text`.
 
 La función `handle_global_command` es llamada desde `routes/webhook.py` y detiene el
 procesamiento normal cuando un comando es reconocido.

--- a/services/global_commands.py
+++ b/services/global_commands.py
@@ -1,5 +1,8 @@
+import re
+
 from services.db import get_connection
 from services.whatsapp_api import enviar_mensaje
+from services.normalize_text import normalize_text
 
 # Diccionario que mapea comandos globales con sus handlers
 GLOBAL_COMMANDS = {}
@@ -19,34 +22,41 @@ def reiniciar_handler(numero, text):
         ('menu_principal',)
     )
     reglas = c.fetchall(); conn.close()
+
+    normalized_text = normalize_text(text)
     for input_db, resp, next_step, tipo_resp, opts, rol_kw in reglas:
-        triggers = [t.strip() for t in (input_db or '').split(',')]
-        if text in triggers:
-            enviar_mensaje(numero, resp, tipo_respuesta=tipo_resp, opciones=opts)
-            if rol_kw:
-                conn2 = get_connection(); c2 = conn2.cursor()
-                c2.execute("SELECT id FROM roles WHERE keyword=%s", (rol_kw,))
-                role = c2.fetchone()
-                if role:
-                    c2.execute(
-                        "INSERT IGNORE INTO chat_roles (numero, role_id) VALUES (%s, %s)",
-                        (numero, role[0])
-                    )
-                    conn2.commit()
-                conn2.close()
-            set_user_step(numero, next_step.strip().lower() if next_step else '')
-            break
+        triggers = [normalize_text(t.strip()) for t in (input_db or '').split(',')]
+        for trigger in triggers:
+            if re.search(rf"\b{re.escape(trigger)}\b", normalized_text):
+                enviar_mensaje(numero, resp, tipo_respuesta=tipo_resp, opciones=opts)
+                if rol_kw:
+                    conn2 = get_connection(); c2 = conn2.cursor()
+                    c2.execute("SELECT id FROM roles WHERE keyword=%s", (rol_kw,))
+                    role = c2.fetchone()
+                    if role:
+                        c2.execute(
+                            "INSERT IGNORE INTO chat_roles (numero, role_id) VALUES (%s, %s)",
+                            (numero, role[0])
+                        )
+                        conn2.commit()
+                    conn2.close()
+                set_user_step(numero, next_step.strip().lower() if next_step else '')
+                break
+        else:
+            continue
+        break
 
 
 # Registrar comandos por defecto
 for cmd in ['reiniciar', 'volver al inicio', 'inicio', 'menú', 'menu', 'ayuda']:
-    GLOBAL_COMMANDS[cmd] = reiniciar_handler
+    GLOBAL_COMMANDS[normalize_text(cmd)] = reiniciar_handler
 
 
 def handle_global_command(numero, text):
     """Procesa comandos globales. Devuelve True si se manejó alguno."""
-    handler = GLOBAL_COMMANDS.get(text)
-    if handler:
-        handler(numero, text)
-        return True
+    normalized_text = normalize_text(text)
+    for cmd, handler in GLOBAL_COMMANDS.items():
+        if re.search(rf"\b{re.escape(cmd)}\b", normalized_text):
+            handler(numero, text)
+            return True
     return False

--- a/services/normalize_text.py
+++ b/services/normalize_text.py
@@ -1,0 +1,15 @@
+import re
+import unicodedata
+
+def normalize_text(text: str) -> str:
+    """Return text without accents, in lowercase and without punctuation."""
+    if not isinstance(text, str):
+        return ''
+    # Remove accents and convert to lowercase
+    normalized = unicodedata.normalize('NFD', text)
+    normalized = ''.join(ch for ch in normalized if unicodedata.category(ch) != 'Mn')
+    normalized = normalized.lower()
+    # Remove punctuation
+    normalized = re.sub(r'[\W_]+', ' ', normalized)
+    return normalized.strip()
+


### PR DESCRIPTION
## Summary
- Add `normalize_text` utility to strip accents, punctuation and lowercase text
- Use normalized text and regex-based matching for reiniciar handler and global commands
- Document normalized registration of global commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a511044bf483238e35b7ca645aea47