### PR TITLE
feat: add configurable media root

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -9,3 +9,6 @@ DB_PORT=<puerto_railway>
 DB_USER=<usuario_mysql>
 DB_PASSWORD=<contraseña_mysql>
 DB_NAME=<nombre_base_de_datos>
+
+# Ruta persistente para archivos subidos (usar volumen externo)
+MEDIA_ROOT=/ruta/externa/persistente

--- a/README.md
+++ b/README.md
@@ -130,4 +130,6 @@ Si no se establece, la aplicación usará `http://localhost:8501`.
 
 ## Almacenamiento de medios subidos por el usuario
 
-Los archivos generados por los usuarios (por ejemplo, en `static/uploads/` u otras carpetas de medios) no deben versionarse en Git. Durante los despliegues, mantén estas rutas en un volumen persistente o en un almacenamiento externo para evitar su borrado accidental.
+Los archivos generados por los usuarios se guardan en la ruta indicada por la variable de entorno `MEDIA_ROOT`. Esta ruta debe apuntar a un volumen externo o a un directorio persistente fuera del repositorio. Si no se define, la aplicación usará `static/uploads` dentro del proyecto.
+
+Estos archivos no deben versionarse en Git; durante los despliegues, mantén `MEDIA_ROOT` en un volumen persistente o en un almacenamiento externo para evitar su borrado accidental.

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from routes.tablero_routes import tablero_bp
 
 # Carga .env y crea la app
 load_dotenv()
-os.makedirs(Config.UPLOAD_FOLDER, exist_ok=True)
+os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 app = Flask(__name__)
 app.config.from_object(Config)
 app.secret_key = os.getenv('SECRET_KEY')

--- a/config.py
+++ b/config.py
@@ -18,5 +18,5 @@ class Config:
     DB_PASSWORD = os.getenv('DB_PASSWORD')
     DB_NAME     = os.getenv('DB_NAME')
 
-    BASEDIR       = os.path.dirname(os.path.abspath(__file__))
-    UPLOAD_FOLDER = os.path.join(BASEDIR, 'static', 'uploads')
+    BASEDIR    = os.path.dirname(os.path.abspath(__file__))
+    MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASEDIR, "static", "uploads"))

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -9,8 +9,8 @@ from services.db import get_connection, get_chat_state, update_chat_state
 chat_bp = Blueprint('chat', __name__)
 
 # Carpeta de subida debe coincidir con la de whatsapp_api
-UPLOAD_FOLDER = Config.UPLOAD_FOLDER
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+MEDIA_ROOT = Config.MEDIA_ROOT
+os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 
 @chat_bp.route('/')
 def index():
@@ -286,7 +286,7 @@ def send_image():
     # Guarda archivo en disco
     filename = secure_filename(img.filename)
     unique   = f"{uuid.uuid4().hex}_{filename}"
-    path = os.path.join(UPLOAD_FOLDER, unique)
+    path = os.path.join(MEDIA_ROOT, unique)
     img.save(path)
 
     # URL pública
@@ -336,7 +336,7 @@ def send_document():
 
     filename = secure_filename(document.filename)
     unique   = f"{uuid.uuid4().hex}_{filename}"
-    path     = os.path.join(UPLOAD_FOLDER, unique)
+    path     = os.path.join(MEDIA_ROOT, unique)
     document.save(path)
 
     doc_url = url_for('static', filename=f'uploads/{unique}', _external=True)
@@ -384,7 +384,7 @@ def send_audio():
     # Guarda archivo en disco
     filename = secure_filename(audio.filename)
     unique   = f"{uuid.uuid4().hex}_{filename}"
-    path = os.path.join(UPLOAD_FOLDER, unique)
+    path = os.path.join(MEDIA_ROOT, unique)
     audio.save(path)
 
     # Envía el audio por la API
@@ -431,7 +431,7 @@ def send_video():
 
     filename = secure_filename(video.filename)
     unique   = f"{uuid.uuid4().hex}_{filename}"
-    path     = os.path.join(UPLOAD_FOLDER, unique)
+    path     = os.path.join(MEDIA_ROOT, unique)
     video.save(path)
 
     tipo_envio = 'bot_video' if origen == 'bot' else 'asesor'

--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -7,8 +7,8 @@ import os
 import uuid
 
 config_bp = Blueprint('configuracion', __name__)
-UPLOAD_FOLDER = Config.UPLOAD_FOLDER
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+MEDIA_ROOT = Config.MEDIA_ROOT
+os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 
 def _require_admin():
     # Debe haber usuario logueado y el rol 'admin' en la lista de roles
@@ -121,7 +121,7 @@ def _reglas_view(template_name):
                     if media_file and media_file.filename:
                         filename = secure_filename(media_file.filename)
                         unique = f"{uuid.uuid4().hex}_{filename}"
-                        path = os.path.join(UPLOAD_FOLDER, unique)
+                        path = os.path.join(MEDIA_ROOT, unique)
                         media_file.save(path)
                         url = url_for('static', filename=f'uploads/{unique}', _external=True)
                         medias.append((url, media_file.mimetype))
@@ -260,7 +260,7 @@ def botones():
                     if media_file and media_file.filename:
                         filename = secure_filename(media_file.filename)
                         unique = f"{uuid.uuid4().hex}_{filename}"
-                        path = os.path.join(UPLOAD_FOLDER, unique)
+                        path = os.path.join(MEDIA_ROOT, unique)
                         media_file.save(path)
                         url = url_for('static', filename=f'uploads/{unique}', _external=True)
                         medias.append((url, media_file.mimetype))

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -48,7 +48,7 @@ def set_user_step(numero, step, estado='espera_usuario'):
     user_steps[numero] = step
     update_chat_state(numero, step, estado)
 
-os.makedirs(Config.UPLOAD_FOLDER, exist_ok=True)
+os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 
 
 @register_handler('barra_medida')
@@ -173,7 +173,7 @@ def webhook():
 
                     audio_bytes = download_audio(media_id)
                     filename = f"{media_id}.{ext}"
-                    path = os.path.join(Config.UPLOAD_FOLDER, filename)
+                    path = os.path.join(Config.MEDIA_ROOT, filename)
                     with open(path, 'wb') as f:
                         f.write(audio_bytes)
 
@@ -213,7 +213,7 @@ def webhook():
                     # 1) Descarga bytes y guardar en static/uploads
                     media_bytes = download_audio(media_id)
                     filename    = f"{media_id}.{ext}"
-                    path        = os.path.join(Config.UPLOAD_FOLDER, filename)
+                    path        = os.path.join(Config.MEDIA_ROOT, filename)
                     with open(path, 'wb') as f:
                         f.write(media_bytes)
 

--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -8,6 +8,7 @@ from services.db import guardar_mensaje
 
 TOKEN    = Config.META_TOKEN
 PHONE_ID = Config.PHONE_NUMBER_ID
+os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 
 def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones=None, reply_to_wa_id=None):
     url = f"https://graph.facebook.com/v19.0/{PHONE_ID}/messages"
@@ -185,7 +186,7 @@ def get_media_url(media_id):
 
     ext = resp2.headers.get("Content-Type", "").split("/")[-1] or "bin"
     filename = f"{media_id}.{ext}"
-    path     = os.path.join(Config.UPLOAD_FOLDER, filename)
+    path     = os.path.join(Config.MEDIA_ROOT, filename)
     with open(path, "wb") as f:
         f.write(resp2.content)
 


### PR DESCRIPTION
## Summary
- make media directory configurable with `MEDIA_ROOT`
- update routes and services to reference `Config.MEDIA_ROOT`
- document persistent media storage in README and `.env_example`

## Testing
- `python -m py_compile config.py routes/configuracion.py routes/chat_routes.py routes/webhook.py services/whatsapp_api.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a523e4a8ac83238543801a1368d154