### PR TITLE
Log bot response when rule not found

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -391,6 +391,10 @@ def webhook():
                         conn2.close()
                     set_user_step(from_number, next_step.strip().lower() if next_step else '')
                 else:
-                    enviar_mensaje(from_number, "No entendí tu respuesta, intenta de nuevo.")
+                    guardar_mensaje(
+                        from_number,
+                        "No entendí tu respuesta, intenta de nuevo.",
+                        "bot"
+                    )
                     update_chat_state(from_number, step, 'sin_regla')
     return jsonify({'status':'received'}), 200


### PR DESCRIPTION
## Summary
- Persist 'no entendí' response as a bot message when no rule matches

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a52aa647608323a64e08547d5afd46