### PR TITLE
Improve WhatsApp API error handling

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -138,7 +138,7 @@ def send_message():
         return jsonify({'error': 'No autorizado'}), 403
 
     # Envía por la API y guarda internamente
-    enviar_mensaje(
+    ok = enviar_mensaje(
         numero,
         texto,
         tipo='asesor',
@@ -146,6 +146,8 @@ def send_message():
         opciones=opciones,
         reply_to_wa_id=reply_to_wa_id,
     )
+    if not ok:
+        return jsonify({'error': 'No se pudo enviar el mensaje'}), 500
     row = get_chat_state(numero)
     step = row[0] if row else ''
     update_chat_state(numero, step, 'asesor')

--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -133,6 +133,8 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
 
     resp = requests.post(url, headers=headers, json=data)
     print(f"[WA API] {resp.status_code} — {resp.text}")
+    if not resp.ok:
+        return False
     try:
         wa_id = resp.json().get("messages", [{}])[0].get("id")
     except Exception:
@@ -172,6 +174,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             media_id=None,
             media_url=opciones
         )
+    return True
 
 def get_media_url(media_id):
     resp1 = requests.get(

--- a/templates/index.html
+++ b/templates/index.html
@@ -599,11 +599,15 @@
                     reply_to_wa_id: replyTo
                   })
                 }));
-                Promise.all(envios).then(()=>{
-                  replyTo=null;
-                  replyPreviewEl.style.display='none';
-                  replyPreviewEl.innerHTML='';
-                  loadMessages(); fetchChatList();
+                Promise.all(envios).then(responses => {
+                  if (responses.every(r => r.ok)) {
+                    replyTo=null;
+                    replyPreviewEl.style.display='none';
+                    replyPreviewEl.innerHTML='';
+                    loadMessages(); fetchChatList();
+                  } else {
+                    alert('No se pudo enviar el mensaje');
+                  }
                 });
               };
               botoneraEl.appendChild(btn);
@@ -620,7 +624,11 @@
           method:'POST',
           headers:{'Content-Type':'application/json'},
           body:JSON.stringify({numero:currentChat,mensaje:txt,reply_to_wa_id:replyTo})
-        }).then(()=>{
+        }).then(res=>{
+          if(!res.ok){
+            alert('No se pudo enviar el mensaje');
+            return;
+          }
           inp.value='';
           replyTo=null;
           replyPreviewEl.style.display='none';


### PR DESCRIPTION
## Summary
- Return success flag from WhatsApp API client and skip DB write on failure
- Propagate send errors to chat route and UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5e1aeb98c832396782897e953a834