### PR TITLE
Allow multiple media URLs in rules

### DIFF
--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -5,6 +5,7 @@ from werkzeug.utils import secure_filename
 from config import Config
 import os
 import uuid
+import re
 
 config_bp = Blueprint('configuracion', __name__)
 MEDIA_ROOT = Config.MEDIA_ROOT
@@ -126,7 +127,7 @@ def _reglas_view(template_name):
                         url = url_for('static', filename=f'uploads/{unique}', _external=True)
                         medias.append((url, media_file.mimetype))
                 if media_url_field:
-                    for url in [u.strip() for u in media_url_field.split(',') if u.strip()]:
+                    for url in [u.strip() for u in re.split(r'[\n,]+', media_url_field) if u.strip()]:
                         medias.append((url, None))
                 media_url = medias[0][0] if medias else None
                 media_tipo = medias[0][1] if medias else None

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -99,8 +99,8 @@
         <label for="media" id="label_media_file" style="display:none;">Subir archivo:</label>
         <input type="file" id="media" name="media[]" multiple style="display:none;">
 
-        <label for="media_url" id="label_media_url" style="display:none;">o URL del archivo:</label>
-        <input type="text" id="media_url" name="media_url" style="display:none;">
+        <label for="media_url" id="label_media_url" style="display:none;">URLs de archivos (separadas por comas o saltos de línea):</label>
+        <textarea id="media_url" name="media_url" style="display:none;" placeholder="URL1, URL2&#10;URL3"></textarea>
 
         <label for="rol_keyword">Rol keyword:</label>
         <input type="text" id="rol_keyword" name="rol_keyword">


### PR DESCRIPTION
## Summary
- Support entering multiple media URLs separated by commas or new lines when creating rules
- Replace media URL input with textarea and update label to document the accepted formats

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e35cabd0832395bdbf8ac1529ab4