### PR TITLE
Use rule handler for transcribed audio messages

### DIFF
--- a/services/message_processor.py
+++ b/services/message_processor.py
@@ -1,0 +1,10 @@
+"""Utilidades para delegar procesamiento de mensajes evitando ciclos."""
+
+from typing import Any
+
+
+def handle_text_message(numero: str, texto: str, *args: Any, **kwargs: Any):
+    """Delegar al manejador real sin crear importaciones circulares."""
+    from routes.webhook import handle_text_message as _handle_text_message
+
+    return _handle_text_message(numero, texto, *args, **kwargs)

--- a/services/tasks.py
+++ b/services/tasks.py
@@ -3,6 +3,7 @@ import logging
 from services.transcripcion import transcribir
 from services.db import update_mensaje_texto
 from services.whatsapp_api import enviar_mensaje
+from services.message_processor import handle_text_message
 
 
 def process_audio(
@@ -22,7 +23,7 @@ def process_audio(
         update_mensaje_texto(mensaje_id, texto)
 
         if texto:
-            enviar_mensaje(from_number, f"Transcripción lista: {texto}", tipo='bot')
+            handle_text_message(from_number, texto)
         else:
             enviar_mensaje(
                 from_number,


### PR DESCRIPTION
## Summary
- Route transcription results through `handle_text_message`
- Add a helper to access `handle_text_message` without circular imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60377fd3483238c888628ec5e0753