### PR TITLE
Send text only for first media URL in quick buttons

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -588,12 +588,12 @@
               btn.onclick = () => {
                 if (!currentChat) return;
                 const urls = (b.media_urls && b.media_urls.length) ? b.media_urls : [null];
-                const envios = urls.map(url => fetch('/send_message', {
+                const envios = urls.map((url, index) => fetch('/send_message', {
                   method:'POST',
                   headers:{'Content-Type':'application/json'},
                   body:JSON.stringify({
                     numero: currentChat,
-                    mensaje: b.mensaje,
+                    mensaje: index === 0 ? b.mensaje : '',
                     tipo_respuesta: b.tipo,
                     opciones: url,
                     reply_to_wa_id: replyTo


### PR DESCRIPTION
## Summary
- Adjust quick button sending to include message only on the first media URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a624e7fbb4832398e4dde3be04dbaa