### PR TITLE
Send text only for first media URL, allow multiline quick button messages, and show media URLs

### DIFF
--- a/templates/botones.html
+++ b/templates/botones.html
@@ -60,7 +60,7 @@
 
     <form method="POST" enctype="multipart/form-data">
         <label for="mensaje">Nuevo mensaje:</label>
-        <input type="text" name="mensaje" required>
+        <textarea name="mensaje" rows="3" required></textarea>
         <label for="tipo">Tipo de medio:</label>
         <select name="tipo" id="tipo">
             <option value="texto">Texto</option>
@@ -103,11 +103,12 @@
 
     <h3>Botones actuales</h3>
     <table>
-        <tr><th>ID</th><th>Mensaje</th><th>Acción</th></tr>
+        <tr><th>ID</th><th>Mensaje</th><th>URLs</th><th>Acción</th></tr>
         {% for b in botones %}
         <tr>
             <td>{{ b[0] }}</td>
-            <td>{{ b[1] }}</td>
+            <td style="white-space: pre-line;">{{ b[1] }}</td>
+            <td style="word-break: break-all;">{{ b[3]|default('')|replace('||', '<br>')|safe }}</td>
             <td>
                 <form method="POST" action="{{ url_for('configuracion.eliminar_boton', boton_id=b[0]) }}">
                     <button class="delete-btn" type="submit">Eliminar</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -588,12 +588,12 @@
               btn.onclick = () => {
                 if (!currentChat) return;
                 const urls = (b.media_urls && b.media_urls.length) ? b.media_urls : [null];
-                const envios = urls.map(url => fetch('/send_message', {
+                const envios = urls.map((url, index) => fetch('/send_message', {
                   method:'POST',
                   headers:{'Content-Type':'application/json'},
                   body:JSON.stringify({
                     numero: currentChat,
-                    mensaje: b.mensaje,
+                    mensaje: index === 0 ? b.mensaje : '',
                     tipo_respuesta: b.tipo,
                     opciones: url,
                     reply_to_wa_id: replyTo


### PR DESCRIPTION
## Summary
- Adjust quick button sending to include message only on the first media URL
- Allow multi-line quick button messages and display their line breaks in the button list
- Show media URLs in the quick button configuration table

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a624e7fbb4832398e4dde3be04dbaa