### PR TITLE
feat: add React frontend for chat

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+.DS_Store

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <!-- La aplicación React generada por Vite se montará en este elemento -->
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.37",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.0.2",
+    "vite": "^4.4.5",
+    "eslint": "^8.34.0",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.3.4"
+  }
+}

--- a/frontend/src/ChatTecnimedellin.tsx
+++ b/frontend/src/ChatTecnimedellin.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+
+interface ChatSummary {
+  numero: string;
+  alias?: string;
+}
+
+interface QuickButton {
+  nombre?: string;
+  mensaje: string;
+  tipo: string;
+  media_urls?: string[];
+}
+
+const ChatList: React.FC<{ chats: ChatSummary[]; current: string | null; onSelect: (n: string) => void }> = ({ chats, current, onSelect }) => (
+  <aside className="chat-list">
+    <ul>
+      {chats.map(c => (
+        <li key={c.numero} className={current === c.numero ? 'active' : ''} onClick={() => onSelect(c.numero)}>
+          {c.alias ? `${c.alias} (${c.numero})` : c.numero}
+        </li>
+      ))}
+    </ul>
+  </aside>
+);
+
+const MessageList: React.FC<{ messages: any[] }> = ({ messages }) => (
+  <div className="messages">
+    {messages.map((m, i) => (
+      <div key={i} className="bubble">{m[0]}</div>
+    ))}
+  </div>
+);
+
+const QuickButtons: React.FC<{ buttons: QuickButton[]; onSend: (b: QuickButton) => void }> = ({ buttons, onSend }) => (
+  <div className="quick-buttons">
+    {buttons.map((b, i) => (
+      <button key={i} onClick={() => onSend(b)}>{b.nombre || i + 1}</button>
+    ))}
+  </div>
+);
+
+const ChatTecnimedellin: React.FC = () => {
+  const [chats, setChats] = useState<ChatSummary[]>([]);
+  const [currentChat, setCurrentChat] = useState<string | null>(null);
+  const [messages, setMessages] = useState<any[]>([]);
+  const [text, setText] = useState('');
+  const [buttons, setButtons] = useState<QuickButton[]>([]);
+
+  useEffect(() => {
+    fetch('/get_chat_list')
+      .then(r => r.json())
+      .then(setChats);
+  }, []);
+
+  useEffect(() => {
+    if (!currentChat) return;
+    fetch(`/get_chat/${currentChat}`)
+      .then(r => r.json())
+      .then(data => setMessages(data.mensajes || []));
+    fetch('/get_botones')
+      .then(r => r.json())
+      .then(setButtons);
+  }, [currentChat]);
+
+  const sendText = () => {
+    if (!currentChat || !text.trim()) return;
+    fetch('/send_message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ numero: currentChat, mensaje: text })
+    }).then(res => {
+      if (res.ok) {
+        setText('');
+        fetch(`/get_chat/${currentChat}`)
+          .then(r => r.json())
+          .then(data => setMessages(data.mensajes || []));
+      }
+    });
+  };
+
+  const sendButton = (b: QuickButton) => {
+    if (!currentChat) return;
+    const urls = b.media_urls && b.media_urls.length ? b.media_urls : [null];
+    Promise.all(urls.map((url, index) => fetch('/send_message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        numero: currentChat,
+        mensaje: index === 0 ? b.mensaje : '',
+        tipo_respuesta: b.tipo,
+        opciones: url
+      })
+    }))).then(() => {
+      fetch(`/get_chat/${currentChat}`)
+        .then(r => r.json())
+        .then(data => setMessages(data.mensajes || []));
+    });
+  };
+
+  return (
+    <div className="chat-container">
+      <ChatList chats={chats} current={currentChat} onSelect={setCurrentChat} />
+      <div className="chat-area">
+        <MessageList messages={messages} />
+        <QuickButtons buttons={buttons} onSend={sendButton} />
+        <div className="input-row">
+          <input value={text} onChange={e => setText(e.target.value)} placeholder="Mensaje" />
+          <button onClick={sendText}>Enviar</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatTecnimedellin;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ChatTecnimedellin from './ChatTecnimedellin';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ChatTecnimedellin />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/get_chat_list': 'http://localhost:5000',
+      '/get_chat': 'http://localhost:5000',
+      '/send_message': 'http://localhost:5000',
+      '/get_botones': 'http://localhost:5000',
+      '/send_image': 'http://localhost:5000',
+      '/send_audio': 'http://localhost:5000',
+      '/send_video': 'http://localhost:5000',
+      '/set_alias': 'http://localhost:5000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold Vite React TypeScript frontend
- implement ChatTecnimedellin component with fetch-based chat operations
- replace server template with React mount point

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: tsc: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a63e1dae9c8323badc68d0db9a3c34