### PR TITLE
Build frontend before starting gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn app:app --bind 0.0.0.0:$PORT --workers 4
+web: bash scripts/build_frontend.sh && gunicorn app:app --bind 0.0.0.0:$PORT --workers 4
 streamlit: streamlit run scripts/tablero.py --server.address 0.0.0.0 --server.enableCORS=false --server.enableXsrfProtection=false

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+npm install --prefix frontend
+npm run build --prefix frontend


### PR DESCRIPTION
## Summary
- build frontend assets via new script before running gunicorn
- run script from Procfile so Railway builds client bundle

## Testing
- `pytest`
- `bash scripts/build_frontend.sh >/tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_68a6449887fc83239bd2aa6fef436d60