### PR TITLE
Renderiza bundle de Vite con datos de sesión

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -16,7 +16,22 @@ os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 def index():
     if "user" not in session:
         return redirect(url_for("auth.login"))
-    return render_template('index.html')
+    rol = session.get('rol')
+    roles = session.get('roles', [])
+    role_id = None
+    if rol and rol != 'admin':
+        conn = get_connection()
+        c = conn.cursor()
+        c.execute("SELECT id FROM roles WHERE keyword=%s", (rol,))
+        row = c.fetchone()
+        conn.close()
+        role_id = row[0] if row else None
+    session_data = {
+        'role': rol,
+        'roleId': role_id,
+        'sessionRoles': roles,
+    }
+    return render_template('index.html', session_data=session_data)
 
 @chat_bp.route('/get_chat/<numero>')
 def get_chat(numero):

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chat Tecnimedellín</title>
+    <script id="session-data" type="application/json">
+      {{ session_data | tojson }}
+    </script>
+    <script type="module" crossorigin src="{{ url_for('static', filename='assets/index-8254f1bd.js') }}"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='assets/index-9bbf22be.css') }}">
   </head>
   <body>
     <div id="root"></div>
-    <!-- La aplicación React generada por Vite se montará en este elemento -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Render template with hashed Vite bundle and session data script
- Expose session info from `/` backend route

## Testing
- `python -m py_compile routes/chat_routes.py`
- `pytest`
- ⚠️ `from app import app; client = app.test_client()` (failed: Can't connect to MySQL server on 'localhost:3306')


------
https://chatgpt.com/codex/tasks/task_e_68a647e705088323a059d5cc1ed6c56c