### PR TITLE
Render media messages in chat

### DIFF
--- a/frontend/src/ChatTecnimedellin.tsx
+++ b/frontend/src/ChatTecnimedellin.tsx
@@ -26,11 +26,38 @@ const ChatList: React.FC<{ chats: ChatSummary[]; current: string | null; onSelec
 
 const MessageList: React.FC<{ messages: any[] }> = ({ messages }) => (
   <div className="messages">
-    {messages.map((m, i) => (
-      <div key={i} className="bubble">{m[0]}</div>
-    ))}
+    {messages.map((m, i) => {
+      const [text, tipo, mediaUrl] = m;
+      return (
+        <div key={i} className={`bubble ${tipo}`}>
+          {text && <span>{text}</span>}
+          {mediaUrl && <MediaContent tipo={tipo} url={mediaUrl} />}
+        </div>
+      );
+    })}
   </div>
 );
+
+const MediaContent: React.FC<{ tipo: string; url: string }> = ({ tipo, url }) => {
+  const [error, setError] = useState(false);
+  if (error) {
+    return <div className="media-error">No se pudo cargar el archivo</div>;
+  }
+  if (tipo && tipo.includes('image')) {
+    return <img src={url} className="media-image" onError={() => setError(true)} alt="imagen" />;
+  }
+  if (tipo && tipo.includes('audio')) {
+    return <audio controls src={url} className="media-audio" onError={() => setError(true)} />;
+  }
+  if (tipo && tipo.includes('video')) {
+    return <video controls src={url} className="media-video" onError={() => setError(true)} />;
+  }
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" className="media-link">
+      {url}
+    </a>
+  );
+};
 
 const QuickButtons: React.FC<{ buttons: QuickButton[]; onSend: (b: QuickButton) => void }> = ({ buttons, onSend }) => (
   <div className="quick-buttons">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,3 +2,27 @@ body {
   margin: 0;
   font-family: sans-serif;
 }
+
+.media-image,
+.media-video {
+  max-width: 200px;
+  border-radius: 4px;
+  display: block;
+}
+
+.media-audio,
+.media-video {
+  width: 100%;
+  max-width: 250px;
+  margin-top: 4px;
+}
+
+.media-link {
+  color: #0066cc;
+  word-break: break-all;
+}
+
+.media-error {
+  color: #d00;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- Render chat messages using appropriate media components based on message type and URL
- Add React component with error handling for images, audio, video and generic links
- Style media elements for consistent appearance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64907ba98832383ec9a4f6a8018c0