### PR TITLE
Use wa_id for message keys when available

### DIFF
--- a/frontend/src/ChatTecnimedellin.tsx
+++ b/frontend/src/ChatTecnimedellin.tsx
@@ -28,8 +28,9 @@ const MessageList: React.FC<{ messages: any[] }> = ({ messages }) => (
   <div className="messages">
     {messages.map((m, i) => {
       const [text, tipo, mediaUrl] = m;
+      const waId = m[8];
       return (
-        <div key={i} className={`bubble ${tipo}`}>
+        <div key={waId ?? i} className={`bubble ${tipo}`}>
           {text && <span>{text}</span>}
           {mediaUrl && <MediaContent tipo={tipo} url={mediaUrl} />}
         </div>


### PR DESCRIPTION
## Summary
- Ensure MessageList uses WhatsApp `wa_id` as React key when present
- Fall back to index only when `wa_id` is absent

## Testing
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a64a6d40348323a05e8de46d72d6cc