### PR TITLE
Reduce ffmpeg apt install footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci --prefix frontend && npm run build --prefix frontend
 # Stage backend
 FROM python:3.11-slim
 WORKDIR /app
-RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .


### PR DESCRIPTION
## Summary
- minimize apt dependencies for ffmpeg by using `--no-install-recommends`

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a657c52e408323bd26f6dd90116b53