### PR TITLE
feat: load hashed assets via manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ node_modules/
 static/assets/
 frontend/dist/
 static/index.html
+static/manifest.json

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   },
   build: {
     outDir: '../static',
+    manifest: true,
     rollupOptions: {
       input: resolve(__dirname, 'index.html')
     }

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1,6 +1,7 @@
 import os
 import uuid
-from flask import Blueprint, render_template, request, redirect, session, url_for, jsonify
+import json
+from flask import Blueprint, render_template, request, redirect, session, url_for, jsonify, current_app
 from werkzeug.utils import secure_filename
 from config import Config
 from services.whatsapp_api import enviar_mensaje
@@ -31,7 +32,16 @@ def index():
         'roleId': role_id,
         'sessionRoles': roles,
     }
-    return render_template('index.html', session_data=session_data)
+
+    manifest_path = os.path.join(current_app.static_folder, 'manifest.json')
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    entry = manifest.get('index.html', {})
+    js_file = entry.get('file', '')
+    css_files = entry.get('css', [])
+    css_file = css_files[0] if css_files else ''
+
+    return render_template('index.html', session_data=session_data, js_file=js_file, css_file=css_file)
 
 @chat_bp.route('/get_chat/<numero>')
 def get_chat(numero):

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,12 @@
     <script id="session-data" type="application/json">
       {{ session_data | tojson }}
     </script>
-    <script type="module" crossorigin src="{{ url_for('static', filename='assets/index-8254f1bd.js') }}"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='assets/index-9bbf22be.css') }}">
+    {% if js_file %}
+    <script type="module" crossorigin src="{{ url_for('static', filename=js_file) }}"></script>
+    {% endif %}
+    {% if css_file %}
+    <link rel="stylesheet" href="{{ url_for('static', filename=css_file) }}">
+    {% endif %}
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- build frontend with Vite manifest
- load hashed CSS and JS assets using manifest entries
- ignore build manifest in git

## Testing
- `npm run build`
- `python -m py_compile routes/chat_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a65c3eace083238305040df1a01453