### PR TITLE
Move scripts to end of body in index template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,17 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chat Tecnimedellín</title>
-    <script id="session-data" type="application/json">
-      {{ session_data | tojson }}
-    </script>
-    {% if js_file %}
-    <script type="module" crossorigin src="{{ url_for('static', filename=js_file) }}"></script>
-    {% endif %}
     {% if css_file %}
     <link rel="stylesheet" href="{{ url_for('static', filename=css_file) }}">
     {% endif %}
   </head>
   <body>
     <div id="root"></div>
+    <script id="session-data" type="application/json">
+      {{ session_data | tojson }}
+    </script>
+    {% if js_file %}
+    <script type="module" crossorigin src="{{ url_for('static', filename=js_file) }}"></script>
+    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Move session-data and bundle scripts after root div in templates/index.html to match old frontend structure
- Keep stylesheet link in head

## Testing
- `pytest`
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: No files matching the pattern "." were found)


------
https://chatgpt.com/codex/tasks/task_e_68a66039dd548323823985051bfaa79a