### PR TITLE
Fallback a script de desarrollo

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -34,6 +34,8 @@ def index():
     }
 
     manifest_path = os.path.join(current_app.static_folder, 'manifest.json')
+    if not os.path.exists(manifest_path):
+        return render_template('index.html', session_data=session_data, js_file=None, css_file=None)
     with open(manifest_path) as f:
         manifest = json.load(f)
     entry = manifest.get('index.html', {})

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,8 @@
     </script>
     {% if js_file %}
     <script type="module" crossorigin src="{{ url_for('static', filename=js_file) }}"></script>
+    {% else %}
+    <script type="module" src="/src/index.tsx"></script>
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Comprobar si existe `manifest.json` antes de cargarlo
- Usar script de desarrollo cuando no se genera el `manifest`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a664df3458832380aa502dfd899a1e