### PR TITLE
docs: add frontend compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Si usas Docker, asegúrate de añadir ffmpeg en la imagen:
 RUN apt-get update && apt-get install -y ffmpeg
 ```
 
+## Compilación del frontend
+
+Para generar la versión de producción de la interfaz React, ejecuta:
+
+```bash
+npm ci --prefix frontend
+npm run build --prefix frontend
+```
+
+También puedes usar el script `scripts/build_frontend.sh` para realizar estos pasos automáticamente.
+
+El archivo `static/manifest.json` es obligatorio; sin él, la interfaz React no se cargará correctamente.
+
 ✅ Estado actual
 La app ya está funcionando con:
 


### PR DESCRIPTION
## Summary
- document how to build the React frontend
- note the requirement of `static/manifest.json` for React UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66a57dcbc83239b8ec4255fbe205a