### PR TITLE
chore: use npm ci for frontend build

### DIFF
--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-npm install --prefix frontend
+npm ci --prefix frontend
 npm run build --prefix frontend


### PR DESCRIPTION
## Summary
- replace npm install with npm ci in frontend build script for reproducible installs

## Testing
- `./scripts/build_frontend.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a66bf041288323bcd20ff5d2b6db49