### PR TITLE
style: enhance chat interface layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,3 +26,95 @@ body {
   color: #d00;
   font-size: 0.9em;
 }
+
+/* Layout general del chat */
+.chat-container {
+  display: flex;
+  height: 100vh;
+}
+
+.chat-list {
+  display: flex;
+  flex-direction: column;
+  width: 250px;
+  background-color: #f4f4f4;
+  border-right: 1px solid #ddd;
+  overflow-y: auto;
+}
+
+.chat-area {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  background-color: #fff;
+}
+
+.messages {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.bubble {
+  max-width: 70%;
+  padding: 6px 10px;
+  margin: 4px 0;
+  border-radius: 8px;
+  word-break: break-word;
+}
+
+.bubble.bot,
+.bubble.asesor,
+.bubble[class*="bot_"],
+.bubble[class*="asesor_"] {
+  background-color: #dcf8c6;
+  align-self: flex-end;
+}
+
+.bubble.cliente,
+.bubble[class*="cliente_"] {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  align-self: flex-start;
+}
+
+.quick-buttons {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid #ddd;
+  background-color: #fafafa;
+}
+
+.quick-buttons button {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  background-color: #eceff1;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid #ddd;
+  background-color: #fff;
+}
+
+.input-row input:not([type="file"]) {
+  flex: 1;
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.input-row button {
+  padding: 6px 12px;
+  background-color: #0084ff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- structure chat container, list and area with flex layouts
- add scrollable messages section and styled bubbles for sent vs received
- style quick action buttons and input row with coherent spacing and colors

## Testing
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a67013e7948323bdc93938fd0ba684