### PR TITLE
refactor: replace ChatTecnimedellin with ChatInterface

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import ChatTecnimedellin from './ChatTecnimedellin';
+import ChatInterface from './components/ChatInterface';
 import './index.css';
 
 interface SessionData {
@@ -14,6 +14,6 @@ const sessionData: SessionData = dataEl ? JSON.parse(dataEl.textContent || '{}')
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ChatTecnimedellin role={sessionData.role} roleId={sessionData.roleId} sessionRoles={sessionData.sessionRoles} />
+    <ChatInterface role={sessionData.role} roleId={sessionData.roleId} sessionRoles={sessionData.sessionRoles} />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- refactor: swap ChatTecnimedellin import and usage for ChatInterface

## Testing
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a671156ec083238a828332276909a7