### PR TITLE
Reemplaza componente ChatTecnimedellin por ChatInterface

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,10 +10,15 @@ interface SessionData {
 }
 
 const dataEl = document.getElementById('session-data');
-const sessionData: SessionData = dataEl ? JSON.parse(dataEl.textContent || '{}') : { role: null, roleId: null, sessionRoles: [] };
+const sessionData: SessionData = dataEl
+  ? JSON.parse(dataEl.textContent || '{}')
+  : { role: null, roleId: null, sessionRoles: [] };
+
+(window as any).sessionData = sessionData;
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ChatInterface role={sessionData.role} roleId={sessionData.roleId} sessionRoles={sessionData.sessionRoles} />
-  </React.StrictMode>
+    <ChatInterface />
+  </React.StrictMode>,
 );
+


### PR DESCRIPTION
## Summary
- Renderiza `ChatInterface` en la entrada principal y expone los datos de sesión globalmente

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a671f5a8a48323bbc5cc9502c07886