### PR TITLE
feat: improve chat bubble styling and accessibility

### DIFF
--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -35,14 +35,20 @@ const MessageList: React.FC<MessageListProps> = ({ messages }) => {
   return (
     <div className="flex-1 p-2 overflow-y-auto">
       {messages.map((m, i) => {
+        const base = 'max-w-[70%] p-2 my-1 rounded-lg break-words transition-opacity duration-300 animate-fade-in';
+        const isBot =
+          m.tipo === 'bot' ||
+          m.tipo === 'asesor' ||
+          m.tipo?.startsWith('bot_') ||
+          m.tipo?.startsWith('asesor_');
+        const isAdmin = m.tipo === 'admin' || m.tipo?.startsWith('admin_');
         const bubbleClass = [
-          'max-w-[70%] p-2 my-1 rounded-lg break-words',
-          (m.tipo === 'bot' || m.tipo === 'asesor' || m.tipo?.startsWith('bot_') || m.tipo?.startsWith('asesor_'))
-            ? 'bg-primary self-end text-white'
-            : 'bg-white border self-start'
+          base,
+          isBot ? 'bg-bubble-bot self-end' : isAdmin ? 'bg-bubble-admin self-end' : 'bg-bubble-user self-start'
         ].join(' ');
+        const label = isBot ? 'bot' : isAdmin ? 'admin' : 'usuario';
         return (
-          <div key={m.waId ?? i} className={bubbleClass}>
+          <div key={m.waId ?? i} className={bubbleClass} role="status" aria-label={`Mensaje de ${label}`}>
             {m.text && <span>{m.text}</span>}
             {m.mediaUrl && <MediaContent tipo={m.tipo} url={m.mediaUrl} />}
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -134,3 +134,27 @@ body {
     @apply text-xs font-semibold px-2 py-0.5 rounded;
   }
 }
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@layer utilities {
+  .bg-bubble-user {
+    @apply bg-white border text-black;
+  }
+  .bg-bubble-bot {
+    @apply bg-primary text-white;
+  }
+  .bg-bubble-admin {
+    @apply bg-secondary text-white;
+  }
+  .animate-fade-in {
+    animation: fade-in 0.3s ease-in-out;
+  }
+}


### PR DESCRIPTION
## Summary
- add Tailwind utility classes for user, bot, and admin bubbles
- animate message entry with fade-in transition
- include role and aria-label on messages for accessibility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: No files matching the pattern "." were found)


------
https://chatgpt.com/codex/tasks/task_e_68a677a857708323a89816f15af1a42f