### PR TITLE
feat: add quick actions dropdown for media attachments

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -106,28 +106,20 @@ const ChatInterface: React.FC = () => {
       .catch(() => setError('Error al enviar el mensaje'));
   };
 
-  const sendMedia = (
-    e: React.ChangeEvent<HTMLInputElement>,
-    tipo: 'image' | 'audio' | 'video'
-  ) => {
-    if (!currentChat || !e.target.files || !e.target.files.length) return;
-    const file = e.target.files[0];
+  const sendMedia = async (file: File, tipo: 'image' | 'audio' | 'video') => {
+    if (!currentChat) throw new Error('No chat seleccionado');
     const formData = new FormData();
     formData.append('numero', currentChat);
     formData.append(tipo, file);
-    fetch(`/send_${tipo}`, {
+    const res = await fetch(`/send_${tipo}`, {
       method: 'POST',
-      body: formData
-    })
-      .then(res => {
-        if (res.ok) {
-          e.target.value = '';
-          refreshMessages();
-        } else {
-          setError('Error al enviar el archivo');
-        }
-      })
-      .catch(() => setError('Error al enviar el archivo'));
+      body: formData,
+    });
+    if (!res.ok) {
+      setError('Error al enviar el archivo');
+      throw new Error('upload failed');
+    }
+    refreshMessages();
   };
 
   return (

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -1,0 +1,47 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface DropdownProps {
+  trigger: React.ReactNode;
+  children: React.ReactNode;
+}
+
+// A simple reusable dropdown menu component
+const Dropdown: React.FC<DropdownProps> = ({ trigger, children }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="p-2"
+      >
+        {trigger}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute bottom-full mb-2 flex flex-col rounded border bg-white shadow"
+          onClick={() => setOpen(false)}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;
+

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
+import QuickActions from './QuickActions';
 
 interface MessageInputProps {
   text: string;
   onTextChange: (value: string) => void;
   onSendText: () => void;
-  onSendMedia: (
-    e: React.ChangeEvent<HTMLInputElement>,
-    tipo: 'image' | 'audio' | 'video'
-  ) => void;
+  onSendMedia: (file: File, tipo: 'image' | 'audio' | 'video') => Promise<void>;
 }
 
 const MessageInput: React.FC<MessageInputProps> = ({
@@ -17,9 +15,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
   onSendMedia,
 }) => (
   <div className="flex items-center gap-2 p-2 border-t">
-    <input type="file" accept="image/*" onChange={e => onSendMedia(e, 'image')} />
-    <input type="file" accept="audio/*" onChange={e => onSendMedia(e, 'audio')} />
-    <input type="file" accept="video/*" onChange={e => onSendMedia(e, 'video')} />
+    <QuickActions onSendMedia={onSendMedia} />
     <input
       value={text}
       onChange={e => onTextChange(e.target.value)}

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -1,0 +1,185 @@
+import React, { useRef, useState } from 'react';
+import Dropdown from './Dropdown';
+
+interface QuickActionsProps {
+  onSendMedia: (file: File, tipo: 'image' | 'audio' | 'video') => Promise<void>;
+}
+
+// inline SVG icons to avoid external dependencies
+const PaperclipIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="h-5 w-5"
+  >
+    <path d="M21.44 11.05l-9.19 9.19a5.6 5.6 0 01-7.92-7.92l10.31-10.3a3.8 3.8 0 015.38 5.38L9.88 18.54a2 2 0 01-2.83-2.83l9.9-9.9" />
+  </svg>
+);
+
+const ImageIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="h-5 w-5"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <circle cx="8.5" cy="8.5" r="1.5" />
+    <path d="M21 15l-5-5L5 21" />
+  </svg>
+);
+
+const MicIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="h-5 w-5"
+  >
+    <rect x="9" y="2" width="6" height="11" rx="3" />
+    <path d="M12 17v5M8 21h8" />
+    <path d="M5 10v2a7 7 0 0014 0v-2" />
+  </svg>
+);
+
+const VideoIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    className="h-5 w-5"
+  >
+    <rect x="3" y="5" width="15" height="14" rx="2" />
+    <path d="M21 7l-5 4 5 4V7z" />
+  </svg>
+);
+
+const LoaderIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-5 w-5 animate-spin"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+      strokeOpacity="0.25"
+      className="text-gray-400"
+    />
+    <path d="M22 12a10 10 0 00-10-10" className="text-current" />
+  </svg>
+);
+
+const QuickActions: React.FC<QuickActionsProps> = ({ onSendMedia }) => {
+  const imageRef = useRef<HTMLInputElement>(null);
+  const audioRef = useRef<HTMLInputElement>(null);
+  const videoRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+    tipo: 'image' | 'audio' | 'video'
+  ) => {
+    if (!e.target.files || !e.target.files.length) return;
+    const file = e.target.files[0];
+    setLoading(true);
+    setMessage('Enviando archivo...');
+    try {
+      await onSendMedia(file, tipo);
+      setMessage('Archivo enviado correctamente');
+    } catch {
+      setMessage('Error al enviar el archivo');
+    } finally {
+      setLoading(false);
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <div className="relative flex items-center">
+      <Dropdown
+        trigger={
+          <div aria-describedby="attach-tip">
+            <PaperclipIcon />
+            <span id="attach-tip" role="tooltip" className="sr-only">
+              Adjuntar archivo
+            </span>
+          </div>
+        }
+      >
+        <button
+          onClick={() => imageRef.current?.click()}
+          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+          role="menuitem"
+          aria-describedby="image-tip"
+        >
+          <ImageIcon />
+          <span id="image-tip" role="tooltip" className="sr-only">
+            Imagen
+          </span>
+        </button>
+        <button
+          onClick={() => audioRef.current?.click()}
+          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+          role="menuitem"
+          aria-describedby="audio-tip"
+        >
+          <MicIcon />
+          <span id="audio-tip" role="tooltip" className="sr-only">
+            Audio
+          </span>
+        </button>
+        <button
+          onClick={() => videoRef.current?.click()}
+          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+          role="menuitem"
+          aria-describedby="video-tip"
+        >
+          <VideoIcon />
+          <span id="video-tip" role="tooltip" className="sr-only">
+            Video
+          </span>
+        </button>
+      </Dropdown>
+
+      <input
+        type="file"
+        ref={imageRef}
+        accept="image/*"
+        onChange={e => handleChange(e, 'image')}
+        className="hidden"
+      />
+      <input
+        type="file"
+        ref={audioRef}
+        accept="audio/*"
+        onChange={e => handleChange(e, 'audio')}
+        className="hidden"
+      />
+      <input
+        type="file"
+        ref={videoRef}
+        accept="video/*"
+        onChange={e => handleChange(e, 'video')}
+        className="hidden"
+      />
+
+      {loading && <LoaderIcon />}
+      <p className="sr-only" aria-live="polite">
+        {message}
+      </p>
+    </div>
+  );
+};
+
+export default QuickActions;
+


### PR DESCRIPTION
## Summary
- add reusable Dropdown menu component
- add QuickActions with icons, tooltips, and media upload handling
- wire QuickActions into message input and update media sending logic

## Testing
- `npm run lint` *(fails: No files matching the pattern '.' were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6787b66988323bea8d18f631fe680