### PR TITLE
feat: improve responsive layout and accessibility

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -123,10 +123,10 @@ const ChatInterface: React.FC = () => {
   };
 
   return (
-    <div className="flex h-screen bg-gradient-primary">
+    <div className="flex h-screen flex-col bg-gradient-primary md:flex-row">
       {error && <div className="error-container">{error}</div>}
       <Sidebar contacts={chats} currentChat={currentChat} onSelect={setCurrentChat} />
-      <div className="flex flex-1 flex-col bg-white">
+      <main className="flex flex-1 flex-col bg-white">
         <MessageList messages={messages} />
         <QuickButtons buttons={buttons} onSend={sendButton} />
         <MessageInput
@@ -135,7 +135,7 @@ const ChatInterface: React.FC = () => {
           onSendText={sendText}
           onSendMedia={sendMedia}
         />
-      </div>
+      </main>
     </div>
   );
 };

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -26,7 +26,7 @@ const Dropdown: React.FC<DropdownProps> = ({ trigger, children }) => {
         onClick={() => setOpen(o => !o)}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="p-2"
+        className="p-2 focus:outline-none focus:ring-2 focus:ring-primary"
       >
         {trigger}
       </button>

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -20,9 +20,14 @@ const MessageInput: React.FC<MessageInputProps> = ({
       value={text}
       onChange={e => onTextChange(e.target.value)}
       placeholder="Mensaje"
-      className="flex-1 p-1 border rounded"
+      aria-label="Escribir mensaje"
+      className="flex-1 p-1 border rounded focus:outline-none focus:ring-2 focus:ring-primary"
     />
-    <button onClick={onSendText} className="px-3 py-1 rounded bg-primary text-white shadow-elegant">
+    <button
+      onClick={onSendText}
+      aria-label="Enviar mensaje"
+      className="px-3 py-1 rounded bg-primary text-white shadow-elegant focus:outline-none focus:ring-2 focus:ring-primary"
+    >
       Enviar
     </button>
   </div>

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -118,7 +118,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({ onSendMedia }) => {
       >
         <button
           onClick={() => imageRef.current?.click()}
-          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
           role="menuitem"
           aria-describedby="image-tip"
         >
@@ -129,7 +129,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({ onSendMedia }) => {
         </button>
         <button
           onClick={() => audioRef.current?.click()}
-          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
           role="menuitem"
           aria-describedby="audio-tip"
         >
@@ -140,7 +140,7 @@ const QuickActions: React.FC<QuickActionsProps> = ({ onSendMedia }) => {
         </button>
         <button
           onClick={() => videoRef.current?.click()}
-          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100"
+          className="flex items-center gap-2 px-3 py-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary"
           role="menuitem"
           aria-describedby="video-tip"
         >

--- a/frontend/src/components/QuickButtons.tsx
+++ b/frontend/src/components/QuickButtons.tsx
@@ -11,7 +11,7 @@ const QuickButtons: React.FC<QuickButtonsProps> = ({ buttons, onSend }) => (
     {buttons.map((b, i) => (
       <button
         key={i}
-        className="px-3 py-1 border rounded bg-white shadow-elegant"
+        className="px-3 py-1 border rounded bg-white shadow-elegant focus:outline-none focus:ring-2 focus:ring-primary"
         onClick={() => onSend(b)}
       >
         {b.nombre || i + 1}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -22,12 +22,16 @@ const Sidebar: React.FC<SidebarProps> = ({ contacts, currentChat, onSelect }) =>
   });
 
   return (
-    <aside className="flex flex-col w-64 bg-secondary text-white shadow-elegant">
+    <nav
+      className="flex flex-col w-full sm:w-56 md:w-64 lg:w-72 bg-secondary text-white shadow-elegant"
+      aria-label="Lista de chats"
+    >
       <div className="p-2">
         <input
           type="text"
           placeholder="Buscar..."
-          className="w-full p-2 rounded text-black"
+          aria-label="Buscar chats"
+          className="w-full p-2 rounded text-black focus:outline-none focus:ring-2 focus:ring-primary"
           value={query}
           onChange={e => setQuery(e.target.value)}
         />
@@ -36,10 +40,13 @@ const Sidebar: React.FC<SidebarProps> = ({ contacts, currentChat, onSelect }) =>
         {filtered.map(c => (
           <li
             key={c.numero}
-            className={`flex items-center gap-2 p-2 cursor-pointer hover:bg-primary/10 ${
+            role="button"
+            tabIndex={0}
+            className={`flex items-center gap-2 p-2 cursor-pointer hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary ${
               currentChat === c.numero ? 'bg-primary/10' : ''
             }`}
             onClick={() => onSelect(c.numero)}
+            onKeyDown={e => e.key === 'Enter' && onSelect(c.numero)}
           >
             <Avatar name={c.alias || c.numero} photoUrl={c.avatarUrl} />
             <div className="flex flex-col">
@@ -52,7 +59,7 @@ const Sidebar: React.FC<SidebarProps> = ({ contacts, currentChat, onSelect }) =>
           </li>
         ))}
       </ul>
-    </aside>
+    </nav>
   );
 };
 


### PR DESCRIPTION
## Summary
- reorganize chat and sidebar with responsive flex layouts
- enhance focus styles and aria labels for inputs and buttons
- use semantic elements for navigation and main chat content

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6798fb0b08323bf1e8c376da5e9b2