### PR TITLE
Add Tailwind and PostCSS configuration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "engines": { "node": "20" },
+  "engines": {
+    "node": "20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -18,11 +20,14 @@
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^4.2.0",
-    "typescript": "^5.0.2",
-    "vite": "^4.4.5",
+    "autoprefixer": "^10.4.16",
     "eslint": "^8.34.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.3.4"
+    "eslint-plugin-react-refresh": "^0.3.4",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.0.2",
+    "vite": "^4.4.5"
   }
 }

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};


### PR DESCRIPTION
## Summary
- configure PostCSS with Tailwind and Autoprefixer
- add Tailwind, PostCSS, and Autoprefixer as development dependencies

## Testing
- `npm install -D tailwindcss postcss autoprefixer` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm run dev` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68a67b2f94948323ae2e14109342b885