### PR TITLE
Adjust settings menu height to content

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -315,7 +315,7 @@
       <div class="sidebar-header">
         <button id="settingsBtn">⚙️</button>
       </div>
-      <div id="settingsMenu" class="attach-menu">
+      <div id="settingsMenu">
         <a href="{{ url_for('configuracion.reglas') }}">Reglas</a>
         <a href="{{ url_for('configuracion.botones') }}">Botones</a>
         {% if session.get('roles') and 'admin' in session['roles'] %}


### PR DESCRIPTION
## Summary
- remove `attach-menu` class from `settingsMenu` so menu only grows to fit its options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b9be9dcc8323aa13a852c6c3c657