### PR TITLE
feat: add responsive tablero layout with external assets

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -1,0 +1,137 @@
+:root {
+  --bg-page: #434343;
+  --bg-sidebar: #F5F9F8;
+  --bg-chat: #F5F9F8;
+  --accent: #00A884;
+  --accent-hover: #007C67;
+  --bubble-user: #D2F5F0;
+  --bubble-bot: #F7F3B7;
+  --bubble-asesor: #C0F2C9;
+  --text-main: #212121;
+  --text-light: #ffffff;
+  --border-color: #B2DFDB;
+  --timestamp-color: #666666;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background: var(--bg-page) url('/static/fondo_general.jpeg') center/cover repeat;
+  color: var(--text-main);
+}
+
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background: var(--accent);
+  color: var(--text-light);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+  z-index: 1000;
+}
+
+#menu-toggle {
+  background: none;
+  border: none;
+  color: var(--text-light);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.back-btn {
+  background: var(--accent);
+  color: var(--text-light);
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  transition: background 0.3s;
+}
+
+.back-btn:hover {
+  background: var(--accent-hover);
+}
+
+.sidebar {
+  position: fixed;
+  top: 60px;
+  left: 0;
+  width: 220px;
+  height: calc(100% - 60px);
+  background: var(--bg-sidebar);
+  overflow-y: auto;
+  transition: transform 0.3s ease;
+}
+
+.sidebar ul {
+  list-style: none;
+}
+
+.sidebar li a {
+  display: block;
+  padding: 1rem;
+  color: var(--text-main);
+  text-decoration: none;
+}
+
+.sidebar li a:hover {
+  background: var(--accent);
+  color: var(--text-light);
+}
+
+.content {
+  margin-top: 60px;
+  margin-left: 220px;
+  padding: 20px;
+  transition: margin-left 0.3s ease;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.reports {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  text-align: center;
+}
+
+.card canvas {
+  margin-top: 20px;
+  width: 100%;
+  height: auto;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    transform: translateX(-100%);
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .content {
+    margin-left: 0;
+  }
+}

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -1,0 +1,134 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const menuToggle = document.getElementById('menu-toggle');
+  const sidebar = document.querySelector('.sidebar');
+  if (menuToggle && sidebar) {
+    menuToggle.addEventListener('click', () => {
+      sidebar.classList.toggle('open');
+    });
+  }
+
+  fetch('/datos_totales')
+    .then(response => response.json())
+    .then(data => {
+      document.getElementById('totalEnviados').textContent = data.enviados;
+      document.getElementById('totalRecibidos').textContent = data.recibidos;
+
+      const ctx = document.getElementById('graficoTotales').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: ['Enviados', 'Recibidos'],
+          datasets: [{
+            label: 'Mensajes',
+            data: [data.enviados, data.recibidos],
+            backgroundColor: ['rgba(54, 162, 235, 0.5)', 'rgba(255, 99, 132, 0.5)'],
+            borderColor: ['rgba(54, 162, 235, 1)', 'rgba(255, 99, 132, 1)'],
+            borderWidth: 1
+          }]
+        },
+        options: {
+          scales: {
+            y: { beginAtZero: true }
+          }
+        }
+      });
+    });
+
+  fetch('/datos_tablero')
+    .then(response => response.json())
+    .then(data => {
+      const labels = data.map(item => item.numero);
+      const values = data.map(item => item.palabras);
+      const ctx = document.getElementById('grafico').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Palabras por chat',
+            data: values,
+            backgroundColor: 'rgba(54, 162, 235, 0.5)',
+            borderColor: 'rgba(54, 162, 235, 1)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          scales: {
+            y: { beginAtZero: true }
+          }
+        }
+      });
+    });
+
+  fetch('/datos_top_numeros')
+    .then(response => response.json())
+    .then(data => {
+      const labels = data.map(item => item.numero);
+      const values = data.map(item => item.mensajes);
+      const ctx = document.getElementById('graficoTopNumeros').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Mensajes por número',
+            data: values,
+            backgroundColor: 'rgba(75, 192, 192, 0.5)',
+            borderColor: 'rgba(75, 192, 192, 1)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          indexAxis: 'y',
+          scales: {
+            x: { beginAtZero: true }
+          }
+        }
+      });
+    });
+
+  fetch('/datos_palabras')
+    .then(response => response.json())
+    .then(data => {
+      const labels = data.map(item => item.palabra);
+      const values = data.map(item => item.frecuencia);
+      const ctx = document.getElementById('grafico_palabras').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Palabras más frecuentes',
+            data: values,
+            backgroundColor: 'rgba(255, 159, 64, 0.5)',
+            borderColor: 'rgba(255, 159, 64, 1)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          scales: {
+            y: { beginAtZero: true }
+          }
+        }
+      });
+    });
+
+  fetch('/datos_roles')
+    .then(response => response.json())
+    .then(data => {
+      const labels = data.map(item => item.rol);
+      const values = data.map(item => item.mensajes);
+      const ctx = document.getElementById('grafico_roles').getContext('2d');
+      const colors = ['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40'];
+      new Chart(ctx, {
+        type: 'pie',
+        data: {
+          labels: labels,
+          datasets: [{
+            data: values,
+            backgroundColor: labels.map((_, i) => colors[i % colors.length])
+          }]
+        }
+      });
+    });
+});

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -4,193 +4,40 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Tablero</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='tablero.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <style>
-        body {
-            margin: 0;
-            font-family: 'Segoe UI', sans-serif;
-            background-image: url("{{ url_for('static', filename='fondo_general.jpeg') }}");
-            background-size: cover;
-            background-position: center;
-            background-repeat: repeat;
-        }
-        .back-btn { position: absolute; top: 20px; right: 20px; }
-        .back-btn button {
-            background-color: #3498db;
-            color: white;
-            border: none;
-            border-radius: 6px;
-            padding: 10px 20px;
-            font-size: 14px;
-            cursor: pointer;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        .dashboard {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 20px;
-            padding: 20px;
-        }
-        .card {
-            width: 100%;
-            max-width: 600px;
-            background: rgba(255, 255, 255, 0.9);
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-            padding: 20px;
-            text-align: center;
-        }
-        .card canvas {
-            margin-top: 20px;
-            width: 100%;
-            height: auto;
-        }
-    </style>
 </head>
 <body>
-    <div class="dashboard">
-        <div class="back-btn">
-            <a href="{{ url_for('chat.index') }}"><button>Volver al inicio</button></a>
-        </div>
-        <div class="card" id="totalesCard">
-            <h3>Totales de mensajes</h3>
-            <p>Enviados: <span id="totalEnviados">0</span></p>
-            <p>Recibidos: <span id="totalRecibidos">0</span></p>
-            <canvas id="graficoTotales"></canvas>
-        </div>
-        <div class="card"><canvas id="grafico"></canvas></div>
-        <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
-        <div class="card"><canvas id="grafico_palabras"></canvas></div>
-        <div class="card"><canvas id="grafico_roles"></canvas></div>
-    </div>
-    <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        fetch("{{ url_for('tablero.datos_totales') }}")
-            .then(response => response.json())
-            .then(data => {
-                document.getElementById('totalEnviados').textContent = data.enviados;
-                document.getElementById('totalRecibidos').textContent = data.recibidos;
+    <header class="header">
+        <button id="menu-toggle">☰</button>
+        <h1>Tablero</h1>
+        <a class="back-btn" href="{{ url_for('chat.index') }}">Volver</a>
+    </header>
 
-                const ctx = document.getElementById('graficoTotales').getContext('2d');
-                new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: ['Enviados', 'Recibidos'],
-                        datasets: [{
-                            label: 'Mensajes',
-                            data: [data.enviados, data.recibidos],
-                            backgroundColor: ['rgba(54, 162, 235, 0.5)', 'rgba(255, 99, 132, 0.5)'],
-                            borderColor: ['rgba(54, 162, 235, 1)', 'rgba(255, 99, 132, 1)'],
-                            borderWidth: 1
-                        }]
-                    },
-                    options: {
-                        scales: {
-                            y: { beginAtZero: true }
-                        }
-                    }
-                });
-            });
+    <nav class="sidebar">
+        <ul>
+            <li><a href="#totalesCard">Totales</a></li>
+            <li><a href="#reportes">Reportes</a></li>
+        </ul>
+    </nav>
 
-        fetch("{{ url_for('tablero.datos_tablero') }}")
-            .then(response => response.json())
-            .then(data => {
-                const labels = data.map(item => item.numero);
-                const values = data.map(item => item.palabras);
-                const ctx = document.getElementById('grafico').getContext('2d');
-                new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Palabras por chat',
-                            data: values,
-                            backgroundColor: 'rgba(54, 162, 235, 0.5)',
-                            borderColor: 'rgba(54, 162, 235, 1)',
-                            borderWidth: 1
-                        }]
-                    },
-                    options: {
-                        scales: {
-                            y: { beginAtZero: true }
-                        }
-                    }
-                });
-            });
+    <main class="content">
+        <section class="cards">
+            <div class="card" id="totalesCard">
+                <h3>Totales de mensajes</h3>
+                <p>Enviados: <span id="totalEnviados">0</span></p>
+                <p>Recibidos: <span id="totalRecibidos">0</span></p>
+                <canvas id="graficoTotales"></canvas>
+            </div>
+        </section>
+        <section class="reports" id="reportes">
+            <div class="card"><canvas id="grafico"></canvas></div>
+            <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
+            <div class="card"><canvas id="grafico_palabras"></canvas></div>
+            <div class="card"><canvas id="grafico_roles"></canvas></div>
+        </section>
+    </main>
 
-        fetch("{{ url_for('tablero.datos_top_numeros') }}")
-            .then(response => response.json())
-            .then(data => {
-                const labels = data.map(item => item.numero);
-                const values = data.map(item => item.mensajes);
-                const ctx = document.getElementById('graficoTopNumeros').getContext('2d');
-                new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Mensajes por número',
-                            data: values,
-                            backgroundColor: 'rgba(75, 192, 192, 0.5)',
-                            borderColor: 'rgba(75, 192, 192, 1)',
-                            borderWidth: 1
-                        }]
-                    },
-                    options: {
-                        indexAxis: 'y',
-                        scales: {
-                            x: { beginAtZero: true }
-                        }
-                    }
-                });
-            });
-
-        fetch("{{ url_for('tablero.datos_palabras') }}")
-            .then(response => response.json())
-            .then(data => {
-                const labels = data.map(item => item.palabra);
-                const values = data.map(item => item.frecuencia);
-                const ctx = document.getElementById('grafico_palabras').getContext('2d');
-                new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Palabras más frecuentes',
-                            data: values,
-                            backgroundColor: 'rgba(255, 159, 64, 0.5)',
-                            borderColor: 'rgba(255, 159, 64, 1)',
-                            borderWidth: 1
-                        }]
-                    },
-                    options: {
-                        scales: {
-                            y: { beginAtZero: true }
-                        }
-                    }
-                });
-            });
-
-        fetch("{{ url_for('tablero.datos_roles') }}")
-            .then(response => response.json())
-            .then(data => {
-                const labels = data.map(item => item.rol);
-                const values = data.map(item => item.mensajes);
-                const ctx = document.getElementById('grafico_roles').getContext('2d');
-                const colors = ['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40'];
-                new Chart(ctx, {
-                    type: 'pie',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            data: values,
-                            backgroundColor: labels.map((_, i) => colors[i % colors.length])
-                        }]
-                    }
-                });
-            });
-    });
-    </script>
+    <script src="{{ url_for('static', filename='tablero.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `tablero.css` for dashboard layout with fixed header, collapsible sidebar and responsive cards
- move all Chart.js dashboard logic into `tablero.js`
- refactor `tablero.html` to use new assets and classes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c7e348f08323ae3d4d29820067f8