### PR TITLE
refactor: centralize color palette and use variables

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,23 @@
+    :root {
+      --bg-page:        #434343;  /* fondo general, muy suave verdoso */
+      --bg-sidebar:     #F5F9F8;  /* blanco puro para la barra lateral */
+      --bg-chat:        #F5F9F8;  /* fondo del chat más claro aún */
+
+      --accent:         #00A884;  /* verde WhatsApp moderno */
+      --accent-hover:   #007C67;  /* verde más oscuro para hover */
+
+      --bubble-user:    #D2F5F0;  /* mensajes del cliente */
+      --bubble-bot:     #F7F3B7;  /* gris suave, para el bot */
+      --bubble-asesor:  #C0F2C9;  /* verde más claro, asesor */
+
+      --text-main:      #212121;  /* texto oscuro pero suave */
+      --text-light:     #ffffff;  /* texto sobre fondo oscuro */
+
+      --border-color: #B2DFDB; /* tono suave basado en el acento */
+      --timestamp-color: #666666; /* color sutil para hora */
+      --font-base: 'Segoe UI', sans-serif;
+    }
+
     * { box-sizing: border-box; margin:0; padding:0; }
     body {
       font-family: var(--font-base);
@@ -367,20 +387,24 @@
       text-align: left;
     }
     .delete-btn {
-      background: #e74c3c;
+      background: var(--accent);
       color: var(--text-light);
       border: none;
       padding: 6px 12px;
       border-radius: 4px;
       cursor: pointer;
     }
+    .delete-btn:hover {
+      background: var(--accent-hover);
+    }
+
     .top-right {
       position: absolute;
       top: 20px;
       right: 20px;
     }
     .back-btn {
-      background-color: #3498db;
+      background: var(--accent);
       color: var(--text-light);
       border: none;
       border-radius: 6px;
@@ -388,4 +412,7 @@
       font-size: 14px;
       cursor: pointer;
       box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    .back-btn:hover {
+      background: var(--accent-hover);
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,27 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Chat Tecnimedellín{% endblock %}</title>
-  <style>
-    :root {
-      --bg-page:        #434343;  /* fondo general, muy suave verdoso */
-      --bg-sidebar:     #F5F9F8;  /* blanco puro para la barra lateral */
-      --bg-chat:        #F5F9F8;  /* fondo del chat más claro aún */
-
-      --accent:         #00A884;  /* verde WhatsApp moderno */
-      --accent-hover:   #007C67;  /* verde más oscuro para hover */
-
-      --bubble-user:    #D2F5F0;  /* mensajes del cliente */
-      --bubble-bot:     #F7F3B7;  /* gris suave, para el bot */
-      --bubble-asesor:  #C0F2C9;  /* verde más claro, asesor */
-
-      --text-main:      #212121;  /* texto oscuro pero suave */
-      --text-light:     #ffffff;  /* texto sobre fondo oscuro */
-
-      --border-color: #B2DFDB; /* tono suave basado en el acento */
-      --timestamp-color: #666666; /* color sutil para hora */
-      --font-base: 'Segoe UI', sans-serif;
-    }
-  </style>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
## Summary
- move `:root` color variables from base template to `static/style.css`
- replace hard-coded button colors with `var(--accent)` and related variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce1a1e5c8323ad9bf5f03107e548