### PR TITLE
Use global style variables on dashboard

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -1,30 +1,3 @@
-:root {
-  --bg-page: #434343;
-  --bg-sidebar: #F5F9F8;
-  --bg-chat: #F5F9F8;
-  --accent: #00A884;
-  --accent-hover: #007C67;
-  --bubble-user: #D2F5F0;
-  --bubble-bot: #F7F3B7;
-  --bubble-asesor: #C0F2C9;
-  --text-main: #212121;
-  --text-light: #ffffff;
-  --border-color: #B2DFDB;
-  --timestamp-color: #666666;
-}
-
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-body {
-  font-family: 'Segoe UI', sans-serif;
-  background: var(--bg-page) url('/static/fondo_general.jpeg') center/cover repeat;
-  color: var(--text-main);
-}
-
 .header {
   position: fixed;
   top: 0;
@@ -46,19 +19,6 @@ body {
   color: var(--text-light);
   font-size: 1.5rem;
   cursor: pointer;
-}
-
-.back-btn {
-  background: var(--accent);
-  color: var(--text-light);
-  text-decoration: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  transition: background 0.3s;
-}
-
-.back-btn:hover {
-  background: var(--accent-hover);
 }
 
 .sidebar {
@@ -109,7 +69,8 @@ body {
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--text-light);
+  color: var(--text-main);
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 20px;

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Tablero</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='tablero.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Load global `style.css` in dashboard to reuse shared theme variables
- Clean `tablero.css` by removing duplicated root and back button rules
- Ensure dashboard cards use theme colors from `style.css`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d3cd0a78832391d8d356ff4ad1eb