### PR TITLE
Support Railway PORT variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,7 @@ docker-compose up
 ```
 
 El archivo `Procfile` ya no es necesario cuando se utiliza Docker para el despliegue.
+
+## Despliegue en Railway
+
+Railway define la variable de entorno `PORT` (8080) en tiempo de ejecución. El script `start.sh` utiliza automáticamente este valor para enlazar Gunicorn y, en caso de que no esté presente, recurre al puerto 5000 por defecto.

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
 
-gunicorn app:app --bind 0.0.0.0:5000 --workers 4 &
+PORT="${PORT:-5000}"
+gunicorn app:app --bind 0.0.0.0:$PORT --workers 4 &
 streamlit run scripts/tablero.py --server.address 0.0.0.0 --server.enableCORS=false --server.enableXsrfProtection=false


### PR DESCRIPTION
## Summary
- Allow port configuration via `PORT` environment variable in startup script
- Document Railway's `PORT` handling in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a903f064f48323a34a862c004dcb60