### PR TITLE
gráfico temporal para observar la evolución diaria de mensajes

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -115,6 +115,29 @@ def datos_top_numeros():
     return jsonify(data)
 
 
+@tablero_bp.route('/datos_mensajes_diarios')
+def datos_mensajes_diarios():
+    """Devuelve el total de mensajes agrupados por fecha."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT DATE(timestamp) AS fecha, COUNT(*) AS total
+          FROM mensajes
+         GROUP BY DATE(timestamp)
+         ORDER BY fecha
+        """
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    data = [{"fecha": fecha.strftime("%Y-%m-%d"), "total": total} for fecha, total in rows]
+    return jsonify(data)
+
+
 @tablero_bp.route('/datos_totales')
 def datos_totales():
     """Devuelve el total de mensajes enviados y recibidos."""

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -34,6 +34,32 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
 
+  fetch('/datos_mensajes_diarios')
+    .then(response => response.json())
+    .then(data => {
+      const labels = data.map(item => item.fecha);
+      const values = data.map(item => item.total);
+      const ctx = document.getElementById('graficoDiario').getContext('2d');
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Mensajes por día',
+            data: values,
+            fill: false,
+            borderColor: 'rgba(153, 102, 255, 1)',
+            tension: 0.1
+          }]
+        },
+        options: {
+          scales: {
+            y: { beginAtZero: true }
+          }
+        }
+      });
+    });
+
   fetch('/datos_tablero')
     .then(response => response.json())
     .then(data => {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -32,6 +32,7 @@
             </div>
         </section>
         <section class="reports" id="reportes">
+            <div class="card"><canvas id="graficoDiario"></canvas></div>
             <div class="card"><canvas id="grafico"></canvas></div>
             <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
             <div class="card"><canvas id="grafico_palabras"></canvas></div>


### PR DESCRIPTION
## Summary
- implement `/datos_mensajes_diarios` endpoint grouping messages by date
- add dashboard card with `<canvas id="graficoDiario">`
- fetch daily data and render it as a line chart with Chart.js

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae46a90ba48323b7f340f21321601e