### PR TITLE
Add hourly message analytics and chart

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -138,6 +138,29 @@ def datos_mensajes_diarios():
     return jsonify(data)
 
 
+@tablero_bp.route('/datos_mensajes_hora')
+def datos_mensajes_hora():
+    """Devuelve el total de mensajes agrupados por hora."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT HOUR(timestamp) AS hora, COUNT(*) AS total
+          FROM mensajes
+         GROUP BY HOUR(timestamp)
+         ORDER BY hora
+        """
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    data = [{"hora": int(hora), "total": total} for hora, total in rows]
+    return jsonify(data)
+
+
 @tablero_bp.route('/datos_totales')
 def datos_totales():
     """Devuelve el total de mensajes enviados y recibidos."""

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -60,6 +60,36 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
 
+  fetch('/datos_mensajes_hora')
+    .then(response => response.json())
+    .then(data => {
+      const valores = Array(24).fill(0);
+      data.forEach(item => {
+        const h = parseInt(item.hora, 10);
+        if (!isNaN(h)) valores[h] = item.total;
+      });
+      const labels = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, '0'));
+      const ctx = document.getElementById('graficoHora').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Mensajes por hora',
+            data: valores,
+            backgroundColor: 'rgba(255, 206, 86, 0.5)',
+            borderColor: 'rgba(255, 206, 86, 1)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          scales: {
+            y: { beginAtZero: true }
+          }
+        }
+      });
+    });
+
   fetch('/datos_tablero')
     .then(response => response.json())
     .then(data => {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -33,6 +33,7 @@
         </section>
         <section class="reports" id="reportes">
             <div class="card"><canvas id="graficoDiario"></canvas></div>
+            <div class="card"><canvas id="graficoHora"></canvas></div>
             <div class="card"><canvas id="grafico"></canvas></div>
             <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
             <div class="card"><canvas id="grafico_palabras"></canvas></div>


### PR DESCRIPTION
## Summary
- provide `/datos_mensajes_hora` endpoint to count messages grouped by hour
- add hourly chart canvas to dashboard template
- fetch hourly data and render 24-hour bar chart in client JS

## Testing
- `python -m py_compile routes/tablero_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae4741fe908323a2d998b16696e7fb