### PR TITLE
Agregar gráfico de distribución de tipos

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -161,6 +161,22 @@ def datos_mensajes_hora():
     return jsonify(data)
 
 
+@tablero_bp.route('/datos_tipos')
+def datos_tipos():
+    """Devuelve la cantidad de mensajes agrupados por tipo."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT tipo, COUNT(*) FROM mensajes GROUP BY tipo")
+    rows = cur.fetchall()
+    conn.close()
+
+    data = [{"tipo": tipo or "desconocido", "total": count} for tipo, count in rows]
+    return jsonify(data)
+
+
 @tablero_bp.route('/datos_totales')
 def datos_totales():
     """Devuelve el total de mensajes enviados y recibidos."""

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -187,4 +187,23 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
     });
+
+  fetch('/datos_tipos')
+    .then(response => response.json())
+    .then(data => {
+      const labels = data.map(item => item.tipo);
+      const values = data.map(item => item.total);
+      const ctx = document.getElementById('graficoTipos').getContext('2d');
+      const colors = ['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40','#8E5EA2','#3CBA9F','#E8C3B9','#C45850'];
+      new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: labels,
+          datasets: [{
+            data: values,
+            backgroundColor: labels.map((_, i) => colors[i % colors.length])
+          }]
+        }
+      });
+    });
 });

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -38,6 +38,7 @@
             <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
             <div class="card"><canvas id="grafico_palabras"></canvas></div>
             <div class="card"><canvas id="grafico_roles"></canvas></div>
+            <div class="card"><canvas id="graficoTipos"></canvas></div>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- Añadir endpoint `/datos_tipos` para contar mensajes agrupados por tipo
- Mostrar gráfico de distribución de tipos en el tablero con Chart.js
- Incorporar canvas correspondiente en la plantilla del tablero

## Testing
- `python -m py_compile routes/tablero_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae482ea5b48323b655f4632f1ec041