### PR TITLE
Add word cloud for frequent terms and adjustable limit

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -9,11 +9,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');
+  const limitInput = document.getElementById('limit');
 
   function buildQuery() {
     const params = new URLSearchParams();
     if (startInput.value) params.append('start', startInput.value);
     if (endInput.value) params.append('end', endInput.value);
+    if (limitInput && limitInput.value) params.append('limit', limitInput.value);
     const q = params.toString();
     return q ? `?${q}` : '';
   }
@@ -164,20 +166,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const values = data.map(item => item.frecuencia);
         const ctx = document.getElementById('grafico_palabras').getContext('2d');
         new Chart(ctx, {
-          type: 'bar',
+          type: 'wordCloud',
           data: {
             labels: labels,
             datasets: [{
               label: 'Palabras más frecuentes',
-              data: values,
-              backgroundColor: 'rgba(255, 159, 64, 0.5)',
-              borderColor: 'rgba(255, 159, 64, 1)',
-              borderWidth: 1
+              data: values
             }]
           },
           options: {
-            scales: {
-              y: { beginAtZero: true }
+            plugins: {
+              legend: { display: false }
             }
           }
         });
@@ -224,6 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   startInput.addEventListener('change', cargarDatos);
   endInput.addEventListener('change', cargarDatos);
+  if (limitInput) limitInput.addEventListener('change', cargarDatos);
 
   cargarDatos();
 });

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='tablero.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-wordcloud"></script>
 </head>
 <body>
     <header class="header">
@@ -20,6 +21,8 @@
         <input type="date" id="fechaInicio">
         <label for="fechaFin">Hasta:</label>
         <input type="date" id="fechaFin">
+        <label for="limit">Límite de palabras:</label>
+        <input type="number" id="limit" min="1" value="10">
     </div>
 
     <nav class="sidebar">


### PR DESCRIPTION
## Summary
- Include chartjs-plugin-wordcloud CDN on dashboard page
- Render frequent terms as a word cloud and support custom word limits

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae49bad3dc8323a29729f52c7fee2b