### PR TITLE
Organize dashboard with responsive grid layout

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -55,6 +55,21 @@
   transition: margin-left 0.3s ease;
 }
 
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  grid-template-areas: "totales graficas";
+  gap: 20px;
+}
+
+.totales {
+  grid-area: totales;
+}
+
+.graficas {
+  grid-area: graficas;
+}
+
 .cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -83,6 +98,12 @@
   height: auto;
 }
 
+@media (max-width: 1024px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
 @media (max-width: 768px) {
   .sidebar {
     transform: translateX(-100%);
@@ -94,5 +115,12 @@
 
   .content {
     margin-left: 0;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "totales"
+      "graficas";
   }
 }

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -33,23 +33,25 @@
     </nav>
 
     <main class="content">
-        <section class="cards">
-            <div class="card" id="totalesCard">
-                <h3>Totales de mensajes</h3>
-                <p>Enviados: <span id="totalEnviados">0</span></p>
-                <p>Recibidos: <span id="totalRecibidos">0</span></p>
-                <canvas id="graficoTotales"></canvas>
-            </div>
-        </section>
-        <section class="reports" id="reportes">
-            <div class="card"><canvas id="graficoDiario"></canvas></div>
-            <div class="card"><canvas id="graficoHora"></canvas></div>
-            <div class="card"><canvas id="grafico"></canvas></div>
-            <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
-            <div class="card"><canvas id="grafico_palabras"></canvas></div>
-            <div class="card"><canvas id="grafico_roles"></canvas></div>
-            <div class="card"><canvas id="graficoTipos"></canvas></div>
-        </section>
+        <div class="dashboard-grid">
+            <section class="cards totales">
+                <div class="card" id="totalesCard">
+                    <h3>Totales de mensajes</h3>
+                    <p>Enviados: <span id="totalEnviados">0</span></p>
+                    <p>Recibidos: <span id="totalRecibidos">0</span></p>
+                    <canvas id="graficoTotales"></canvas>
+                </div>
+            </section>
+            <section class="reports graficas" id="reportes">
+                <div class="card"><canvas id="graficoDiario"></canvas></div>
+                <div class="card"><canvas id="graficoHora"></canvas></div>
+                <div class="card"><canvas id="grafico"></canvas></div>
+                <div class="card"><canvas id="graficoTopNumeros"></canvas></div>
+                <div class="card"><canvas id="grafico_palabras"></canvas></div>
+                <div class="card"><canvas id="grafico_roles"></canvas></div>
+                <div class="card"><canvas id="graficoTipos"></canvas></div>
+            </section>
+        </div>
     </main>
 
     <script src="{{ url_for('static', filename='tablero.js') }}"></script>


### PR DESCRIPTION
## Summary
- group dashboard cards and charts within a dashboard-grid container
- add responsive CSS grid with areas `totales` and `graficas` plus mobile single-column layout

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68ae4b6ade5883239ae9dbb58a7e02c3