### PR TITLE
feat: add neon accent and glass visuals

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5,6 +5,8 @@
 
       --accent:         #00A884;  /* verde WhatsApp moderno */
       --accent-hover:   #007C67;  /* verde más oscuro para hover */
+      --accent-neon:    #39FF14;  /* acento verde neón */
+      --bg-glass:       rgba(255,255,255,0.1); /* fondo translúcido */
 
       --bubble-user:    #D2F5F0;  /* mensajes del cliente */
       --bubble-bot:     #F7F3B7;  /* gris suave, para el bot */
@@ -55,9 +57,9 @@
       margin-bottom:16px;
     }
     #settingsBtn {
-      background:var(--accent); border:none; color:var(--text-light);
+      background:var(--accent-neon); border:none; color:var(--text-light);
       width:36px; height:36px; border-radius:50%; font-size:20px;
-      cursor:pointer; transition:transform 0.2s, background 0.3s;
+      cursor:pointer; transition:transform 0.2s, background 0.3s, color 0.3s;
     }
     #settingsBtn:hover {
       transform:rotate(90deg);
@@ -87,11 +89,11 @@
     }
     #settingsMenu a {
       padding:8px 12px; text-decoration:none;
-      color:var(--text-main); font-size:14px;
-      transition:background 0.3s;
+      color:var(--accent-neon); font-size:14px;
+      transition:background 0.3s, color 0.3s;
     }
     #settingsMenu a:hover {
-      background:var(--accent); color:var(--text-light);
+      background:var(--accent-neon); color:var(--text-light);
     }
     .sidebar h2 {
       color:var(--text-main); text-align:center;
@@ -151,10 +153,10 @@
     }
     #botonera button {
       flex:0 0 auto; padding: 8px 16px; min-width: fit-content;
-      border:none; border-radius:8px; background:var(--accent);
+      border:none; border-radius:8px; background:var(--accent-neon);
       white-space: nowrap;
       color:var(--text-light); cursor:pointer;
-      transition:transform 0.2s,background 0.3s;
+      transition:transform 0.2s, background 0.3s, color 0.3s;
     }
     #botonera button:hover {
       transform:scale(1.1); background:var(--accent-hover);
@@ -242,9 +244,9 @@
     }
     #attachBtn {
       width:40px; height:40px; border:none; border-radius:50%;
-      background:var(--accent); color:var(--text-light);
+      background:var(--accent-neon); color:var(--text-light);
       font-size:24px; cursor:pointer;
-      transition:transform 0.2s,background 0.3s;
+      transition:transform 0.2s, background 0.3s, color 0.3s;
       margin-right:12px; position:relative; overflow:hidden;
     }
     #attachBtn:hover {
@@ -264,11 +266,11 @@
     }
     .attach-item {
       width:36px; height:36px; margin:8px;
-      border-radius:50%; background:var(--accent);
+      border-radius:50%; background:var(--accent-neon);
       color:var(--text-light); display:flex;
       align-items:center; justify-content:center;
       font-size:20px; cursor:pointer;
-      transition:transform 0.2s,background 0.3s;
+      transition:transform 0.2s, background 0.3s, color 0.3s;
     }
     .attach-item:hover {
       transform:scale(1.2); background:var(--accent-hover);
@@ -280,8 +282,8 @@
     }
     #sendBtn {
       padding:10px 20px; border:none; border-radius:20px;
-      background:var(--accent); color:var(--text-light);
-      cursor:pointer; transition:transform 0.2s,background 0.3s;
+      background:var(--accent-neon); color:var(--text-light);
+      cursor:pointer; transition:transform 0.2s, background 0.3s, color 0.3s;
       position:relative; overflow:hidden;
     }
     #sendBtn:hover {
@@ -323,12 +325,13 @@
       border-radius: 4px;
     }
     form button {
-      background: var(--accent);
+      background: var(--accent-neon);
       color: var(--text-light);
       padding: 10px 20px;
       border: none;
       border-radius: 4px;
       cursor: pointer;
+      transition: background 0.3s, color 0.3s;
     }
     form button:hover {
       background: var(--accent-hover);
@@ -336,7 +339,7 @@
 
     /* Reusable primary button with hover transition and ripple effect */
     .btn-primary {
-      background: var(--accent);
+      background: var(--accent-neon);
       color: var(--text-light);
       border: none;
       padding: 10px 20px;
@@ -344,7 +347,7 @@
       cursor: pointer;
       position: relative;
       overflow: hidden;
-      transition: transform 0.2s, background 0.3s;
+      transition: transform 0.2s, background 0.3s, color 0.3s;
     }
     .btn-primary:hover {
       transform: scale(1.05);
@@ -387,12 +390,13 @@
       text-align: left;
     }
     .delete-btn {
-      background: var(--accent);
+      background: var(--accent-neon);
       color: var(--text-light);
       border: none;
       padding: 6px 12px;
       border-radius: 4px;
       cursor: pointer;
+      transition: background 0.3s, color 0.3s;
     }
     .delete-btn:hover {
       background: var(--accent-hover);
@@ -404,7 +408,7 @@
       right: 20px;
     }
     .back-btn {
-      background: var(--accent);
+      background: var(--accent-neon);
       color: var(--text-light);
       border: none;
       border-radius: 6px;
@@ -412,6 +416,7 @@
       font-size: 14px;
       cursor: pointer;
       box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      transition: background 0.3s, color 0.3s;
     }
     .back-btn:hover {
       background: var(--accent-hover);

--- a/static/tablero.css
+++ b/static/tablero.css
@@ -4,21 +4,28 @@
   left: 0;
   right: 0;
   height: 60px;
-  background: var(--accent);
+  background: var(--bg-glass);
   color: var(--text-light);
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 1rem;
   z-index: 1000;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255,255,255,0.2);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
 }
 
 #menu-toggle {
   background: none;
   border: none;
-  color: var(--text-light);
+  color: var(--accent-neon);
   font-size: 1.5rem;
   cursor: pointer;
+  transition: color 0.3s;
+}
+#menu-toggle:hover {
+  color: var(--accent-hover);
 }
 
 .sidebar {
@@ -39,12 +46,13 @@
 .sidebar li a {
   display: block;
   padding: 1rem;
-  color: var(--text-main);
+  color: var(--accent-neon);
   text-decoration: none;
+  transition: color 0.3s, background 0.3s;
 }
 
 .sidebar li a:hover {
-  background: var(--accent);
+  background: var(--accent-neon);
   color: var(--text-light);
 }
 
@@ -84,10 +92,12 @@
 }
 
 .card {
-  background: var(--text-light);
+  background: var(--bg-glass);
   color: var(--text-main);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255,255,255,0.2);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
   padding: 20px;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- add `--accent-neon` and `--bg-glass` variables
- style dashboard header and cards with glass blur, border and shadow
- switch links and buttons to neon accent with smooth color transitions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae4c102a748323bd9798c77f74acab