### PR TITLE
Expose Streamlit port and align compose command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     build: .
     ports:
       - "5000:5000"
+      - "8501:8501"
     env_file:
       - .env
     volumes:
       - .:/app
-    command: bash -lc 'gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app'
+    command: >
+      bash -lc 'if command -v gunicorn >/dev/null 2>&1; then exec gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app; else echo "Gunicorn not found; starting with python app.py" && exec python app.py; fi'


### PR DESCRIPTION
## Summary
- expose Streamlit port 8501 in docker compose
- match docker-compose run command with Dockerfile CMD

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8cbf34e08323bdb7b66ecbe1c17f