### PR TITLE
Use request host for Streamlit iframe

### DIFF
--- a/routes/streamlit_routes.py
+++ b/routes/streamlit_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template_string
+from flask import Blueprint, render_template_string, request
 
 streamlit_bp = Blueprint('streamlit', __name__, url_prefix='/streamlit')
 
@@ -6,6 +6,6 @@ streamlit_bp = Blueprint('streamlit', __name__, url_prefix='/streamlit')
 def dashboard():
     """Render an iframe embedding the Streamlit dashboard."""
     iframe_html = (
-        "<iframe src='http://localhost:8501' style='width:100%; height:100vh; border:none;'></iframe>"
+        f"<iframe src='http://{request.host.split(':')[0]}:8501' style='width:100%; height:100vh; border:none;'></iframe>"
     )
     return render_template_string(iframe_html)


### PR DESCRIPTION
## Summary
- embed Streamlit dashboard using same host as request

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8e20d81483239425f783eb4ab092