### PR TITLE
Make Streamlit iframe URL configurable

### DIFF
--- a/routes/streamlit_routes.py
+++ b/routes/streamlit_routes.py
@@ -1,11 +1,16 @@
-from flask import Blueprint, render_template_string, request
+import os
+
+from flask import Blueprint, render_template_string
+
+from config import Config
 
 streamlit_bp = Blueprint('streamlit', __name__, url_prefix='/streamlit')
 
 @streamlit_bp.route('/')
 def dashboard():
     """Render an iframe embedding the Streamlit dashboard."""
+    iframe_url = os.getenv("STREAMLIT_URL", Config.STREAMLIT_URL)
     iframe_html = (
-        f"<iframe src='http://{request.host.split(':')[0]}:8501' style='width:100%; height:100vh; border:none;'></iframe>"
+        f"<iframe src='{iframe_url}' style='width:100%; height:100vh; border:none;'></iframe>"
     )
     return render_template_string(iframe_html)


### PR DESCRIPTION
## Summary
- Build Streamlit iframe URL from `Config.STREAMLIT_URL`
- Allow overriding the dashboard URL via `STREAMLIT_URL` env var

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0bdf151083238f994bf403c9aeb8