### PR TITLE
Expose port 8080 for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ---- Base image ----
 FROM python:3.11-slim
 
-ENV PYTHONDONTWRITEBYTECODE=1     PYTHONUNBUFFERED=1     PORT=5000
+ENV PYTHONDONTWRITEBYTECODE=1     PYTHONUNBUFFERED=1     PORT=8080
 
 WORKDIR /app
 
@@ -27,7 +27,7 @@ RUN useradd -m appuser && \
 
 USER appuser
 
-EXPOSE 5000 8501
+EXPOSE ${PORT} 8501
 
 # Run Streamlit dashboard alongside Gunicorn
-CMD bash -lc 'streamlit run scripts/tablero.py --server.port 8501 & gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app'
+CMD bash -lc 'streamlit run scripts/tablero.py --server.port 8501 & gunicorn -w 2 -b 0.0.0.0:${PORT:-8080} app:app'


### PR DESCRIPTION
## Summary
- default application port to 8080
- expose 8080 instead of 5000 in Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `docker build -t whatsapp_aceros_test .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af104a88f483238ddc6ba874676a3a