### PR TITLE
feat: add React login scaffold with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 __pycache__/
 *.pyc
 
+# Archivos de Node / React
+node_modules/
+dist/
+
 # Medios generados por los usuarios
 static/uploads/
 uploads/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,10 @@ services:
       bash -lc '(command -v gunicorn >/dev/null &&
                  exec gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app ||
                  exec python app.py)'
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:5173"
+    volumes:
+      - ./frontend:/app
+    command: npm run dev -- --host

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: '#0ea5e9',
+              secondary: '#14b8a6',
+              'primary-dark': '#0284c7'
+            }
+          }
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Login from './Login';
+
+function App() {
+  return <Login />;
+}
+
+export default App;

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+export default function Login() {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const togglePassword = () => setShowPassword((prev) => !prev);
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // TODO: conectar con el backend de autenticación
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary via-secondary to-primary-dark relative overflow-hidden">
+      <div className="relative z-10 w-full max-w-sm px-8 py-10 bg-white/30 backdrop-blur-xl rounded-2xl shadow-xl">
+        <h2 className="text-3xl font-bold text-center text-white mb-6">Iniciar sesión</h2>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="relative">
+            <input
+              id="username"
+              name="username"
+              placeholder="Usuario"
+              className="w-full pl-3 pr-3 py-2 rounded-lg bg-white/60 focus:bg-white/80 placeholder-white/60 text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+          <div className="relative">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              id="password"
+              name="password"
+              placeholder="Contraseña"
+              className="w-full pl-3 pr-10 py-2 rounded-lg bg-white/60 focus:bg-white/80 placeholder-white/60 text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <span
+              className="absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer text-white/70"
+              onClick={togglePassword}
+            >
+              {showPassword ? '🙈' : '👁️'}
+            </span>
+          </div>
+          <button
+            type="submit"
+            className="w-full py-2 rounded-lg bg-primary text-white font-semibold hover:bg-primary-dark transition transform active:scale-95"
+          >
+            Ingresar
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- add React frontend for login
- docker-compose now runs frontend and backend
- ignore Node build artefacts

## Testing
- `python -m pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af216609c48323b7a538af0ff161d8