### PR TITLE
Redirect login to root path

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
         setErrorMessage(data.message || 'Error al iniciar sesión');
       } else {
         // Optional redirect after successful login
-        window.location.href = '/tablero';
+        window.location.href = '/';
       }
     } catch (err) {
       setErrorMessage('Error de conexión');


### PR DESCRIPTION
## Summary
- redirect successful login to platform root instead of `/tablero`

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "framer-motion" from "frontend/src/Login.jsx"; attempted `npm install` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af6a387c4883238baf501116c5feb2