### PR TITLE
Expose role metadata in chat index view

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -18,7 +18,17 @@ def index():
     if "user" not in session:
         return redirect(url_for("auth.login"))
 
-    return render_template('index.html')
+    conn = get_connection()
+    c    = conn.cursor()
+    rol  = session.get('rol')
+    role_id = None
+    if rol != 'admin':
+        c.execute("SELECT id FROM roles WHERE keyword=%s", (rol,))
+        row = c.fetchone()
+        role_id = row[0] if row else None
+    conn.close()
+
+    return render_template('index.html', rol=rol, role_id=role_id)
 
 @chat_bp.route('/get_chat/<numero>')
 def get_chat(numero):


### PR DESCRIPTION
## Summary
- Look up the current user's role ID when loading the chat index
- Pass both role name and ID to `index.html`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7344ddc4832387c62c1ec711b0bc