### PR TITLE
Remove fail-safe from pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python deps first (better layer caching)
 COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt || true
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the app source
 COPY . /app


### PR DESCRIPTION
## Summary
- remove `|| true` from pip install in Dockerfile so dependency installation failures stop the build

## Testing
- `python -m pytest`
- `docker --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af7ab69f608323b776f9067bbf1a40