### PR TITLE
Limit container volume to uploads directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,9 @@ services:
       - "5000:5000"
     env_file:
       - .env
+    # Persist only user uploads instead of mounting the entire project
     volumes:
-      - .:/app
+      - ./static/uploads:/app/static/uploads
     command: >
       bash -lc '(command -v gunicorn >/dev/null &&
                  exec gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app ||


### PR DESCRIPTION
## Summary
- Limit Docker Compose volume to static uploads to keep React build inside container

## Testing
- `pytest`
- `docker compose build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68af7ab1cd348323bc8c048f68b7c7e7