### PR TITLE
Send fallback message and allow customization

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -22,6 +22,7 @@ webhook_bp = Blueprint('webhook', __name__)
 
 VERIFY_TOKEN    = Config.VERIFY_TOKEN
 SESSION_TIMEOUT = Config.SESSION_TIMEOUT
+DEFAULT_FALLBACK_TEXT = "No entendí tu respuesta, intenta de nuevo."
 
 user_last_activity = {}
 user_steps         = {}
@@ -114,7 +115,7 @@ def handle_medicion(numero, texto):
     return True
 
 
-def handle_text_message(numero, texto):
+def handle_text_message(numero, texto, fallback_text: str = DEFAULT_FALLBACK_TEXT):
     now           = datetime.now()
     last_time     = user_last_activity.get(numero)
     session_reset = False
@@ -342,11 +343,8 @@ def handle_text_message(numero, texto):
         return
 
     # ===============  F) FALLBACK  ===============
-    guardar_mensaje(
-        numero,
-        "No entendí tu respuesta, intenta de nuevo.",
-        "bot"
-    )
+    enviar_mensaje(numero, fallback_text)
+    guardar_mensaje(numero, fallback_text, "bot")
     # (Asegúrate de que update_chat_state acepte estos parámetros)
     update_chat_state(numero, step, 'sin_regla')
 


### PR DESCRIPTION
## Summary
- Send fallback message to users before logging it
- Allow customization of fallback text via parameter and constant

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb91228888323a849c9848fef85de