### PR TITLE
Trigger automatic steps after measurement handling

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -113,6 +113,7 @@ def handle_medicion(numero, texto):
                 conn2.commit()
             conn2.close()
         set_user_step(numero, next_step.strip().lower() if next_step else '')
+        trigger_auto_steps(numero)
     except Exception:
         enviar_mensaje(numero, "Por favor ingresa la medida correcta.")
     return True


### PR DESCRIPTION
## Summary
- enqueue automatic transitions by calling `trigger_auto_steps` after setting a user's step in measurement handler

## Testing
- `python -m py_compile routes/webhook.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06605c2ac8323ab77c1c8186f0cbc