### PR TITLE
Initialize user step when missing

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class Config:
     VERIFY_TOKEN = os.getenv('VERIFY_TOKEN')
     DB_PATH = 'database.db'
     SESSION_TIMEOUT = 600
+    INITIAL_STEP = os.getenv('INITIAL_STEP', 'menu_principal')
 
     MAX_TRANSCRIPTION_DURATION_MS = int(os.getenv('MAX_TRANSCRIPTION_DURATION_MS', 60000))
     TRANSCRIPTION_MAX_AVG_TIME_SEC = float(os.getenv('TRANSCRIPTION_MAX_AVG_TIME_SEC', 10))

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -208,9 +208,15 @@ def handle_text_message(numero: str, texto: str):
         user_steps.pop(numero, None)
         delete_chat_state(numero)
     user_last_activity[numero] = now
-    text_norm = normalize_text(texto or "")
+    if not user_steps.get(numero):
+        set_user_step(numero, Config.INITIAL_STEP)
+        process_step_chain(numero, 'iniciar')
+        return
+
     if handle_global_command(numero, texto):
         return
+
+    text_norm = normalize_text(texto or "")
     process_step_chain(numero, text_norm)
 
 

--- a/services/global_commands.py
+++ b/services/global_commands.py
@@ -1,5 +1,6 @@
 import re
 
+from config import Config
 from services.db import get_connection
 from services.whatsapp_api import enviar_mensaje
 from services.normalize_text import normalize_text
@@ -12,7 +13,7 @@ def reiniciar_handler(numero, text):
     """Reinicia el flujo para el usuario y envía el mensaje inicial."""
     from routes.webhook import set_user_step  # Evitar dependencias circulares
 
-    set_user_step(numero, 'menu_principal')
+    set_user_step(numero, Config.INITIAL_STEP)
     enviar_mensaje(numero, "Perfecto, volvamos a empezar.")
 
     conn = get_connection(); c = conn.cursor()
@@ -26,7 +27,7 @@ def reiniciar_handler(numero, text):
          WHERE r.step=%s AND r.input_text=%s
          GROUP BY r.id
         """,
-        ('menu_principal', 'iniciar')
+        (Config.INITIAL_STEP, 'iniciar')
     )
     row = c.fetchone(); conn.close()
 


### PR DESCRIPTION
## Summary
- Add configurable `INITIAL_STEP` to `Config`
- Initialize user step and trigger start chain for new users
- Use `Config.INITIAL_STEP` in global command handlers

## Testing
- `python -m py_compile config.py routes/webhook.py services/global_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68b081347d208323aa8be8360745df05