### PR TITLE
Add fallback logging and production logging configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 from flask import Flask
 from dotenv import load_dotenv
 import os
+import logging
+import sys
 from config import Config
 
 from services.db import init_db
@@ -18,6 +20,17 @@ def create_app():
     app = Flask(__name__)
     # Si usas clase de config:
     app.config.from_object(Config)
+
+    if not app.debug:
+        log_format = '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+        logging.basicConfig(
+            level=logging.INFO,
+            format=log_format,
+            handlers=[
+                logging.FileHandler('app.log'),
+                logging.StreamHandler(sys.stdout)
+            ]
+        )
 
     # Registra blueprints
     app.register_blueprint(auth_bp)

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -128,6 +128,7 @@ def process_step_chain(numero, text_norm=None):
         # No procesar recursivamente otros comodines; esperar nueva entrada
         return
 
+    logging.warning("Fallback en step '%s' para entrada '%s'", step, text_norm)
     enviar_mensaje(numero, DEFAULT_FALLBACK_TEXT)
 
 


### PR DESCRIPTION
## Summary
- log step and normalized text before sending fallback message
- configure application logging to write to app.log and stdout when running in production

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1bea987888323841cb66114cc5c57