### PR TITLE
Order step rules deterministically and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Recepción y procesamiento de mensajes entrantes de WhatsApp vía webhook
 
 Flujo automático basado en reglas configurables (con pasos, respuestas, tipo de mensaje y opciones)
 
+Las reglas de un mismo paso se evalúan en orden ascendente por `id` (o columna de prioridad) para mantener un criterio consistente.
+
 Envío de mensajes por parte del asesor desde la interfaz web
 
 Interfaz tipo WhatsApp Web con:

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -93,6 +93,7 @@ def process_step_chain(numero, text_norm=None):
         return
 
     conn = get_connection(); c = conn.cursor()
+    # Ordenar reglas para evaluar primero las de menor ID (o prioridad).
     c.execute(
         """
         SELECT r.id, r.respuesta, r.siguiente_step, r.tipo,
@@ -102,6 +103,7 @@ def process_step_chain(numero, text_norm=None):
           LEFT JOIN regla_medias m ON r.id = m.regla_id
          WHERE r.step=%s
          GROUP BY r.id
+         ORDER BY r.id
         """,
         (step,),
     )


### PR DESCRIPTION
## Summary
- Ensure step rules are retrieved in a deterministic order by ID
- Document rule evaluation order for future consistency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c190533883238b9599582da76fac