### PR TITLE
Add customizable metadata for list messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ Importación de reglas y botones desde archivos .xlsx
 
 Soporte para mensajes interactivos: texto, botones y listas desplegables
 
+Ejemplo de `opciones` para una lista con textos personalizados:
+
+```json
+{
+  "header": "Menú principal",
+  "button": "Ver opciones",
+  "footer": "Selecciona una opción",
+  "sections": [
+    {
+      "title": "Rápido",
+      "rows": [
+        {"id": "express", "title": "Express", "description": "1 día"}
+      ]
+    }
+  ]
+}
+```
+
 Detección de inactividad para cerrar sesión automática del cliente
 
 🔧 Tecnologías utilizadas

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import json
 from flask import Blueprint, render_template, request, redirect, session, url_for, jsonify
 from werkzeug.utils import secure_filename
 from config import Config
@@ -117,6 +118,23 @@ def send_message():
     texto  = data.get('mensaje')
     tipo_respuesta = data.get('tipo_respuesta', 'texto')
     opciones = data.get('opciones')
+    list_header = data.get('list_header')
+    list_footer = data.get('list_footer')
+    list_button = data.get('list_button')
+    sections    = data.get('sections')
+    if tipo_respuesta == 'lista':
+        if not opciones:
+            try:
+                sections_data = json.loads(sections) if sections else []
+            except Exception:
+                sections_data = []
+            opts = {
+                'header': list_header,
+                'footer': list_footer,
+                'button': list_button,
+                'sections': sections_data
+            }
+            opciones = json.dumps(opts)
     reply_to_wa_id = data.get('reply_to_wa_id')
 
     conn = get_connection()

--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -7,6 +7,7 @@ import os
 import uuid
 import re
 import requests
+import json
 
 config_bp = Blueprint('configuracion', __name__)
 MEDIA_ROOT = Config.MEDIA_ROOT
@@ -164,6 +165,23 @@ def _reglas_view(template_name):
                 media_url = medias[0][0] if medias else None
                 media_tipo = medias[0][1] if medias else None
                 opciones = request.form.get('opciones', '')
+                list_header = request.form.get('list_header')
+                list_footer = request.form.get('list_footer')
+                list_button = request.form.get('list_button')
+                sections_raw = request.form.get('sections')
+                if tipo == 'lista':
+                    if not opciones:
+                        try:
+                            sections = json.loads(sections_raw) if sections_raw else []
+                        except Exception:
+                            sections = []
+                        opts = {
+                            'header': list_header,
+                            'footer': list_footer,
+                            'button': list_button,
+                            'sections': sections
+                        }
+                        opciones = json.dumps(opts)
                 rol_keyword = request.form.get('rol_keyword')
                 calculo = request.form.get('calculo')
                 handler = request.form.get('handler')

--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -40,21 +40,25 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
 
     elif tipo_respuesta == 'lista':
         try:
-            secciones = json.loads(opciones) if opciones else []
+            opts = json.loads(opciones) if opciones else {}
         except Exception:
-            secciones = []
+            opts = {}
+        sections = opts.get("sections", [])
+        header   = opts.get("header") or "Menú"
+        footer   = opts.get("footer") or "Selecciona una opción"
+        button   = opts.get("button") or "Ver opciones"
         data = {
             "messaging_product": "whatsapp",
             "to": numero,
             "type": "interactive",
             "interactive": {
                 "type": "list",
-                "header": {"type": "text", "text": "Menú"},
+                "header": {"type": "text", "text": header},
                 "body": {"text": mensaje},
-                "footer": {"text": "Selecciona una opción"},
+                "footer": {"text": footer},
                 "action": {
-                    "button": "Ver opciones",
-                    "sections": secciones
+                    "button": button,
+                    "sections": sections
                 }
             }
         }

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -11,7 +11,7 @@
 <h2>Configuración de Reglas</h2>
 <p>Para reglas de medición usa "*" en <em>Texto del usuario</em> y define la fórmula en <em>Cálculo</em> con variables como <code>medida</code>, <code>p1</code> o <code>p2</code>. El comodín "*" permite avanzar al siguiente paso sin validar el texto recibido: si es la única regla del paso se ejecutará de forma automática; si hay más reglas, actuará como opción por defecto. Opcionalmente indica un <em>Handler</em> para delegar el cálculo a código externo.</p>
 
-<form method="POST" enctype="multipart/form-data">
+<form id="reglaForm" method="POST" enctype="multipart/form-data">
     <h3>Agregar o actualizar regla</h3>
     <label for="step">Paso actual:</label>
     <input type="text" id="step" name="step" required>
@@ -51,8 +51,18 @@
     <label for="handler">Handler externo:</label>
     <input type="text" id="handler" name="handler">
 
-    <label for="opciones">Opciones (solo para listas, formato JSON):</label><br>
-    <textarea name="opciones" rows="6" cols="60" placeholder='[{"title":"Rápido","rows":[{"id":"express","title":"Express","description":"1 día"}]}]'></textarea>
+    <label for="list_header" class="list-field" style="display:none;">Encabezado de la lista:</label>
+    <input type="text" id="list_header" name="list_header" class="list-field" style="display:none;">
+
+    <label for="list_button" class="list-field" style="display:none;">Texto del botón:</label>
+    <input type="text" id="list_button" name="list_button" class="list-field" style="display:none;">
+
+    <label for="list_footer" class="list-field" style="display:none;">Pie de página (opcional):</label>
+    <input type="text" id="list_footer" name="list_footer" class="list-field" style="display:none;">
+
+    <label for="sections" class="list-field" style="display:none;">Secciones (formato JSON):</label><br>
+    <textarea id="sections" name="sections" class="list-field" style="display:none;" rows="6" cols="60" placeholder='[{"title":"Rápido","rows":[{"id":"express","title":"Express","description":"1 día"}]}]'></textarea>
+    <input type="hidden" name="opciones" id="opciones">
 
     <button type="submit" class="btn-primary">Guardar regla</button>
 </form>
@@ -113,7 +123,39 @@ function toggleMediaFields() {
     document.getElementById('label_media_url').style.display = show ? 'block' : 'none';
 }
 
-document.getElementById('tipo').addEventListener('change', toggleMediaFields);
-window.addEventListener('DOMContentLoaded', toggleMediaFields);
+function toggleListFields() {
+    const isList = document.getElementById('tipo').value === 'lista';
+    document.querySelectorAll('.list-field').forEach(el => {
+        el.style.display = isList ? 'block' : 'none';
+    });
+}
+
+function prepareOptions() {
+    const tipo = document.getElementById('tipo').value;
+    if (tipo === 'lista') {
+        const header = document.getElementById('list_header').value;
+        const button = document.getElementById('list_button').value;
+        const footer = document.getElementById('list_footer').value;
+        const sectionsText = document.getElementById('sections').value;
+        let sections;
+        try {
+            sections = JSON.parse(sectionsText || '[]');
+        } catch (e) {
+            sections = [];
+        }
+        const opts = {header, button, footer, sections};
+        document.getElementById('opciones').value = JSON.stringify(opts);
+    }
+}
+document.getElementById('tipo').addEventListener('change', () => {
+    toggleMediaFields();
+    toggleListFields();
+});
+const form = document.getElementById('reglaForm');
+form.addEventListener('submit', prepareOptions);
+window.addEventListener('DOMContentLoaded', () => {
+    toggleMediaFields();
+    toggleListFields();
+});
 </script>
 {% endblock %}

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -11,7 +11,7 @@
 <h2>Reglas</h2>
 <p>Para reglas de medición usa "*" en <em>Texto del usuario</em> y define la fórmula en <em>Cálculo</em> con variables como <code>medida</code>, <code>p1</code> o <code>p2</code>. El comodín "*" permite avanzar al siguiente paso sin validar el texto recibido: si es la única regla del paso se ejecutará automáticamente; si hay más reglas, actuará como opción por defecto. Opcionalmente indica un <em>Handler</em> para delegar el cálculo a código externo.</p>
 
-<form method="POST" enctype="multipart/form-data">
+<form id="reglaForm" method="POST" enctype="multipart/form-data">
     <h3>Agregar o actualizar regla</h3>
     <label for="step">Paso actual:</label>
     <input type="text" id="step" name="step" required>
@@ -51,8 +51,18 @@
     <label for="handler">Handler externo:</label>
     <input type="text" id="handler" name="handler">
 
-    <label for="opciones">Opciones (solo para listas, formato JSON):</label><br>
-    <textarea name="opciones" rows="6" cols="60" placeholder='[{"title":"Rápido","rows":[{"id":"express","title":"Express","description":"1 día"}]}]'></textarea>
+    <label for="list_header" class="list-field" style="display:none;">Encabezado de la lista:</label>
+    <input type="text" id="list_header" name="list_header" class="list-field" style="display:none;">
+
+    <label for="list_button" class="list-field" style="display:none;">Texto del botón:</label>
+    <input type="text" id="list_button" name="list_button" class="list-field" style="display:none;">
+
+    <label for="list_footer" class="list-field" style="display:none;">Pie de página (opcional):</label>
+    <input type="text" id="list_footer" name="list_footer" class="list-field" style="display:none;">
+
+    <label for="sections" class="list-field" style="display:none;">Secciones (formato JSON):</label><br>
+    <textarea id="sections" name="sections" class="list-field" style="display:none;" rows="6" cols="60" placeholder='[{"title":"Rápido","rows":[{"id":"express","title":"Express","description":"1 día"}]}]'></textarea>
+    <input type="hidden" name="opciones" id="opciones">
 
     <button type="submit" class="btn-primary">Guardar regla</button>
 </form>
@@ -119,7 +129,39 @@ function toggleMediaFields() {
     }
 }
 
-document.getElementById('tipo').addEventListener('change', toggleMediaFields);
-window.addEventListener('DOMContentLoaded', toggleMediaFields);
+function toggleListFields() {
+    const isList = document.getElementById('tipo').value === 'lista';
+    document.querySelectorAll('.list-field').forEach(el => {
+        el.style.display = isList ? 'block' : 'none';
+    });
+}
+
+function prepareOptions() {
+    const tipo = document.getElementById('tipo').value;
+    if (tipo === 'lista') {
+        const header = document.getElementById('list_header').value;
+        const button = document.getElementById('list_button').value;
+        const footer = document.getElementById('list_footer').value;
+        const sectionsText = document.getElementById('sections').value;
+        let sections;
+        try {
+            sections = JSON.parse(sectionsText || '[]');
+        } catch (e) {
+            sections = [];
+        }
+        const opts = {header, button, footer, sections};
+        document.getElementById('opciones').value = JSON.stringify(opts);
+    }
+}
+document.getElementById('tipo').addEventListener('change', () => {
+    toggleMediaFields();
+    toggleListFields();
+});
+const form = document.getElementById('reglaForm');
+form.addEventListener('submit', prepareOptions);
+window.addEventListener('DOMContentLoaded', () => {
+    toggleMediaFields();
+    toggleListFields();
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow enviar_mensaje to accept header, footer and button for list messages
- accept list header/footer/button fields in chat and rule routes
- show list metadata inputs in configuration forms and document JSON structure

## Testing
- `python -m py_compile services/whatsapp_api.py routes/configuracion.py routes/chat_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68b228a038288323b05e009c7b9c94a6