### PR TITLE
Add edit functionality for rules

### DIFF
--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -185,18 +185,15 @@ def _reglas_view(template_name):
                 rol_keyword = request.form.get('rol_keyword')
                 calculo = request.form.get('calculo')
                 handler = request.form.get('handler')
+                regla_id = request.form.get('regla_id')
 
-                c.execute(
-                    "SELECT id FROM reglas WHERE step = %s AND input_text = %s",
-                    (step, input_text)
-                )
-                existente = c.fetchone()
-                if existente:
-                    regla_id = existente[0]
+                if regla_id:
                     c.execute(
                         """
                         UPDATE reglas
-                           SET respuesta = %s,
+                           SET step = %s,
+                               input_text = %s,
+                               respuesta = %s,
                                siguiente_step = %s,
                                tipo = %s,
                                media_url = %s,
@@ -207,7 +204,20 @@ def _reglas_view(template_name):
                                handler = %s
                          WHERE id = %s
                         """,
-                        (respuesta, siguiente_step, tipo, media_url, media_tipo, opciones, rol_keyword, calculo, handler, regla_id)
+                        (
+                            step,
+                            input_text,
+                            respuesta,
+                            siguiente_step,
+                            tipo,
+                            media_url,
+                            media_tipo,
+                            opciones,
+                            rol_keyword,
+                            calculo,
+                            handler,
+                            regla_id,
+                        ),
                     )
                     c.execute("DELETE FROM regla_medias WHERE regla_id=%s", (regla_id,))
                     for url, tipo_media in medias:
@@ -217,16 +227,69 @@ def _reglas_view(template_name):
                         )
                 else:
                     c.execute(
-                        "INSERT INTO reglas (step, input_text, respuesta, siguiente_step, tipo, media_url, media_tipo, opciones, rol_keyword, calculo, handler) "
-                        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-                        (step, input_text, respuesta, siguiente_step, tipo, media_url, media_tipo, opciones, rol_keyword, calculo, handler),
+                        "SELECT id FROM reglas WHERE step = %s AND input_text = %s",
+                        (step, input_text)
                     )
-                    regla_id = c.lastrowid
-                    for url, tipo_media in medias:
+                    existente = c.fetchone()
+                    if existente:
+                        regla_id = existente[0]
                         c.execute(
-                            "INSERT INTO regla_medias (regla_id, media_url, media_tipo) VALUES (%s, %s, %s)",
-                            (regla_id, url, tipo_media),
+                            """
+                            UPDATE reglas
+                               SET respuesta = %s,
+                                   siguiente_step = %s,
+                                   tipo = %s,
+                                   media_url = %s,
+                                   media_tipo = %s,
+                                   opciones = %s,
+                                   rol_keyword = %s,
+                                   calculo = %s,
+                                   handler = %s
+                             WHERE id = %s
+                            """,
+                            (
+                                respuesta,
+                                siguiente_step,
+                                tipo,
+                                media_url,
+                                media_tipo,
+                                opciones,
+                                rol_keyword,
+                                calculo,
+                                handler,
+                                regla_id,
+                            ),
                         )
+                        c.execute("DELETE FROM regla_medias WHERE regla_id=%s", (regla_id,))
+                        for url, tipo_media in medias:
+                            c.execute(
+                                "INSERT INTO regla_medias (regla_id, media_url, media_tipo) VALUES (%s, %s, %s)",
+                                (regla_id, url, tipo_media),
+                            )
+                    else:
+                        c.execute(
+                            "INSERT INTO reglas (step, input_text, respuesta, siguiente_step, tipo, media_url, media_tipo, opciones, rol_keyword, calculo, handler) "
+                            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                            (
+                                step,
+                                input_text,
+                                respuesta,
+                                siguiente_step,
+                                tipo,
+                                media_url,
+                                media_tipo,
+                                opciones,
+                                rol_keyword,
+                                calculo,
+                                handler,
+                            ),
+                        )
+                        regla_id = c.lastrowid
+                        for url, tipo_media in medias:
+                            c.execute(
+                                "INSERT INTO regla_medias (regla_id, media_url, media_tipo) VALUES (%s, %s, %s)",
+                                (regla_id, url, tipo_media),
+                            )
                 conn.commit()
 
         # Listar todas las reglas

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -13,6 +13,7 @@
 
 <form id="reglaForm" method="POST" enctype="multipart/form-data">
     <h3>Agregar o actualizar regla</h3>
+    <input type="hidden" id="regla_id" name="regla_id">
     <label for="step">Paso actual:</label>
     <input type="text" id="step" name="step" required>
 
@@ -105,6 +106,19 @@
         <td>{{ regla[10] or '-' }}</td>
         <td>{{ regla[11] or '-' }}</td>
         <td>
+            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ {
+                "id": regla[0],
+                "step": regla[1],
+                "input_text": regla[2],
+                "respuesta": regla[3],
+                "siguiente_step": regla[4] or "",
+                "tipo": regla[5],
+                "media_urls": (regla[6] or "").split("||"),
+                "opciones": regla[8] or "",
+                "rol_keyword": regla[9] or "",
+                "calculo": regla[10] or "",
+                "handler": regla[11] or ""
+            }|tojson } )'>Editar</button>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla[0]) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>
@@ -157,5 +171,40 @@ window.addEventListener('DOMContentLoaded', () => {
     toggleMediaFields();
     toggleListFields();
 });
+
+function cargarRegla(regla) {
+    document.getElementById('regla_id').value = regla.id;
+    document.getElementById('step').value = regla.step || '';
+    document.getElementById('input_text').value = regla.input_text || '';
+    document.getElementById('respuesta').value = regla.respuesta || '';
+    document.getElementById('siguiente_step').value = regla.siguiente_step || '';
+    document.getElementById('tipo').value = regla.tipo || 'texto';
+    document.getElementById('media').value = '';
+    document.getElementById('media_url').value = (regla.media_urls || []).filter(u => u).join(', ');
+    document.getElementById('rol_keyword').value = regla.rol_keyword || '';
+    document.getElementById('calculo').value = regla.calculo || '';
+    document.getElementById('handler').value = regla.handler || '';
+    document.getElementById('list_header').value = '';
+    document.getElementById('list_button').value = '';
+    document.getElementById('list_footer').value = '';
+    document.getElementById('sections').value = '';
+    document.getElementById('opciones').value = '';
+    if (regla.tipo === 'lista' && regla.opciones) {
+        try {
+            const opts = JSON.parse(regla.opciones);
+            document.getElementById('list_header').value = opts.header || '';
+            document.getElementById('list_button').value = opts.button || '';
+            document.getElementById('list_footer').value = opts.footer || '';
+            document.getElementById('sections').value = JSON.stringify(opts.sections || []);
+            document.getElementById('opciones').value = JSON.stringify(opts);
+        } catch (e) {
+            document.getElementById('opciones').value = regla.opciones || '';
+        }
+    } else {
+        document.getElementById('opciones').value = regla.opciones || '';
+    }
+    toggleMediaFields();
+    toggleListFields();
+}
 </script>
 {% endblock %}

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -13,6 +13,7 @@
 
 <form id="reglaForm" method="POST" enctype="multipart/form-data">
     <h3>Agregar o actualizar regla</h3>
+    <input type="hidden" id="regla_id" name="regla_id">
     <label for="step">Paso actual:</label>
     <input type="text" id="step" name="step" required>
 
@@ -105,6 +106,19 @@
         <td>{{ regla[10] or '-' }}</td>
         <td>{{ regla[11] or '-' }}</td>
         <td>
+            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ {
+                "id": regla[0],
+                "step": regla[1],
+                "input_text": regla[2],
+                "respuesta": regla[3],
+                "siguiente_step": regla[4] or "",
+                "tipo": regla[5],
+                "media_urls": (regla[6] or "").split("||"),
+                "opciones": regla[8] or "",
+                "rol_keyword": regla[9] or "",
+                "calculo": regla[10] or "",
+                "handler": regla[11] or ""
+            }|tojson } )'>Editar</button>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla[0]) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>
@@ -163,5 +177,40 @@ window.addEventListener('DOMContentLoaded', () => {
     toggleMediaFields();
     toggleListFields();
 });
+
+function cargarRegla(regla) {
+    document.getElementById('regla_id').value = regla.id;
+    document.getElementById('step').value = regla.step || '';
+    document.getElementById('input_text').value = regla.input_text || '';
+    document.getElementById('respuesta').value = regla.respuesta || '';
+    document.getElementById('siguiente_step').value = regla.siguiente_step || '';
+    document.getElementById('tipo').value = regla.tipo || 'texto';
+    document.getElementById('media').value = '';
+    document.getElementById('media_url').value = (regla.media_urls || []).filter(u => u).join('\n');
+    document.getElementById('rol_keyword').value = regla.rol_keyword || '';
+    document.getElementById('calculo').value = regla.calculo || '';
+    document.getElementById('handler').value = regla.handler || '';
+    document.getElementById('list_header').value = '';
+    document.getElementById('list_button').value = '';
+    document.getElementById('list_footer').value = '';
+    document.getElementById('sections').value = '';
+    document.getElementById('opciones').value = '';
+    if (regla.tipo === 'lista' && regla.opciones) {
+        try {
+            const opts = JSON.parse(regla.opciones);
+            document.getElementById('list_header').value = opts.header || '';
+            document.getElementById('list_button').value = opts.button || '';
+            document.getElementById('list_footer').value = opts.footer || '';
+            document.getElementById('sections').value = JSON.stringify(opts.sections || []);
+            document.getElementById('opciones').value = JSON.stringify(opts);
+        } catch (e) {
+            document.getElementById('opciones').value = regla.opciones || '';
+        }
+    } else {
+        document.getElementById('opciones').value = regla.opciones || '';
+    }
+    toggleMediaFields();
+    toggleListFields();
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add edit button above delete for existing rules
- preload rule data into form via JavaScript
- update backend to handle rule updates by ID

## Testing
- `python -m py_compile routes/configuracion.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b22b3164088323ac6ee5bb1654dd97