### PR TITLE
Fix onclick JSON closing braces in templates

### DIFF
--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -118,7 +118,7 @@
                 "rol_keyword": regla[9] or "",
                 "calculo": regla[10] or "",
                 "handler": regla[11] or ""
-            }|tojson } )'>Editar</button>
+            }|tojson }})'>Editar</button>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla[0]) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -118,7 +118,7 @@
                 "rol_keyword": regla[9] or "",
                 "calculo": regla[10] or "",
                 "handler": regla[11] or ""
-            }|tojson } )'>Editar</button>
+            }|tojson }})'>Editar</button>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla[0]) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>


### PR DESCRIPTION
## Summary
- fix Jinja onclick call in reglas and configuracion templates by closing JSON expression correctly

## Testing
- `curl -f http://127.0.0.1:5000/reglas -I`
- `curl -L http://127.0.0.1:5000/configuracion -I`


------
https://chatgpt.com/codex/tasks/task_e_68b22d9015048323ac3754d11d343e46