### PR TITLE
Validate list sections before sending

### DIFF
--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -59,6 +59,10 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             header = "Menú"
             footer = "Selecciona una opción"
             button = "Ver opciones"
+        if not sections:
+            fallback = mensaje or "No hay opciones disponibles."
+            print("[WA API] Lista vacía; enviando mensaje de texto de fallback")
+            return enviar_mensaje(numero, fallback, tipo, 'texto', None, reply_to_wa_id)
 
         data = {
             "messaging_product": "whatsapp",

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -138,7 +138,7 @@ function toggleListFields() {
     });
 }
 
-function prepareOptions() {
+function prepareOptions(e) {
     const tipo = document.getElementById('tipo').value;
     if (tipo === 'lista') {
         const header = document.getElementById('list_header').value;
@@ -148,9 +148,17 @@ function prepareOptions() {
         let sections;
         try {
             sections = JSON.parse(sectionsText || '[]');
-        } catch (e) {
+        } catch (err) {
             sections = [];
         }
+
+        const invalid = !Array.isArray(sections) || sections.length === 0 || sections.some(sec => !sec.rows || sec.rows.length === 0);
+        if (invalid) {
+            alert('Debes definir al menos una sección con una o más filas.');
+            e.preventDefault();
+            return;
+        }
+
         const opts = {header, button, footer, sections};
         document.getElementById('opciones').value = JSON.stringify(opts);
     }

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -144,7 +144,7 @@ function toggleListFields() {
     });
 }
 
-function prepareOptions() {
+function prepareOptions(e) {
     const tipo = document.getElementById('tipo').value;
     if (tipo === 'lista') {
         const header = document.getElementById('list_header').value;
@@ -154,9 +154,17 @@ function prepareOptions() {
         let sections;
         try {
             sections = JSON.parse(sectionsText || '[]');
-        } catch (e) {
+        } catch (err) {
             sections = [];
         }
+
+        const invalid = !Array.isArray(sections) || sections.length === 0 || sections.some(sec => !sec.rows || sec.rows.length === 0);
+        if (invalid) {
+            alert('Debes definir al menos una sección con una o más filas.');
+            e.preventDefault();
+            return;
+        }
+
         const opts = {header, button, footer, sections};
         document.getElementById('opciones').value = JSON.stringify(opts);
     }


### PR DESCRIPTION
## Summary
- Add front-end validation for list sections in configuration forms
- Prevent sending WhatsApp list messages without sections, falling back to text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b234c7f3188323b902dda38c07b7e4