### PR TITLE
Add total message and role count cards to dashboard

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -263,3 +263,18 @@ def datos_totales():
     )
 
     return jsonify({"enviados": enviados, "recibidos": recibidos})
+
+
+@tablero_bp.route('/datos_roles_total')
+def datos_roles_total():
+    """Devuelve la cantidad total de roles."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM roles")
+    total = cur.fetchone()[0]
+    conn.close()
+
+    return jsonify({"total_roles": total})

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -50,6 +50,9 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         document.getElementById('totalEnviados').textContent = data.enviados;
         document.getElementById('totalRecibidos').textContent = data.recibidos;
+        const total = data.enviados + data.recibidos;
+        const totalElem = document.getElementById('totalMensajes');
+        if (totalElem) totalElem.textContent = total;
 
         if (chartTotales) chartTotales.destroy();
         const ctx = document.getElementById('graficoTotales').getContext('2d');
@@ -72,6 +75,13 @@ document.addEventListener('DOMContentLoaded', () => {
             }
           }
         });
+      });
+
+    fetch('/datos_roles_total')
+      .then(response => response.json())
+      .then(data => {
+        const rolesElem = document.getElementById('cantidadRoles');
+        if (rolesElem) rolesElem.textContent = data.total_roles;
       });
 
     fetch(`/datos_mensajes_diarios${query}`)

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -36,6 +36,14 @@
 <main class="content">
     <div class="dashboard-grid">
         <section class="cards totales">
+            <div class="card">
+                <h3>Total de mensajes</h3>
+                <p id="totalMensajes">0</p>
+            </div>
+            <div class="card">
+                <h3>Cantidad de roles</h3>
+                <p id="cantidadRoles">0</p>
+            </div>
             <div class="card" id="totalesCard">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
                 <p>Enviados: <span id="totalEnviados">0</span></p>


### PR DESCRIPTION
## Summary
- Add cards for total messages and total roles to dashboard template
- Compute total messages and fetch role count in frontend script
- Provide backend endpoint `/datos_roles_total` to supply role totals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b30a4a81d08323aed20f55693764a7