### PR TITLE
Usar gráfico lineal para mensajes por hora

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -124,15 +124,15 @@ document.addEventListener('DOMContentLoaded', () => {
         if (chartHora) chartHora.destroy();
         const ctx = document.getElementById('graficoHora').getContext('2d');
         chartHora = new Chart(ctx, {
-          type: 'bar',
+          type: 'line',
           data: {
             labels: labels,
             datasets: [{
               label: 'Mensajes por hora',
               data: valores,
-              backgroundColor: 'rgba(255, 206, 86, 0.5)',
+              fill: false,
               borderColor: 'rgba(255, 206, 86, 1)',
-              borderWidth: 1
+              tension: 0.1
             }]
           },
           options: {


### PR DESCRIPTION
## Summary
- Cambia el gráfico de mensajes por hora a tipo `line`
- Ajusta opciones del dataset para estilo lineal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b312092b6c8323a2e807902d6e9249