### PR TITLE
Add roles summary table to dashboard

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -231,6 +231,21 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         const labels = data.map(item => item.rol);
         const values = data.map(item => item.mensajes);
+        const tabla = document.getElementById('tabla_roles');
+        if (tabla) {
+          const tbody = tabla.querySelector('tbody');
+          tbody.innerHTML = '';
+          data.forEach(item => {
+            const row = document.createElement('tr');
+            const rolCell = document.createElement('td');
+            rolCell.textContent = item.rol;
+            const mensajesCell = document.createElement('td');
+            mensajesCell.textContent = item.mensajes;
+            row.appendChild(rolCell);
+            row.appendChild(mensajesCell);
+            tbody.appendChild(row);
+          });
+        }
         if (chartRoles) chartRoles.destroy();
         const ctx = document.getElementById('grafico_roles').getContext('2d');
         const colors = ['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40'];

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -75,6 +75,15 @@
             <div class="card">
                 <h4>Roles</h4>
                 <canvas id="grafico_roles" height="120"></canvas>
+                <table id="tabla_roles">
+                    <thead>
+                        <tr>
+                            <th>Rol</th>
+                            <th>Mensajes</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
             </div>
             <div class="card">
                 <h4>Tipos de Mensaje</h4>


### PR DESCRIPTION
## Summary
- add roles messages table under roles chart in tablero template
- populate roles table using `/datos_roles` alongside pie chart

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b312adbf0c8323ae66025fed5d5133