### PR TITLE
Limit top numbers to 3 and display table

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -117,7 +117,7 @@ def datos_top_numeros():
     if "user" not in session:
         return redirect(url_for('auth.login'))
 
-    limite = request.args.get('limit', 5, type=int)
+    limite = request.args.get('limit', 3, type=int)
 
     start = request.args.get('start')
     end = request.args.get('end')

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -172,11 +172,31 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       });
 
-    fetch(`/datos_top_numeros${query}`)
+    const topParams = new URLSearchParams(query.startsWith('?') ? query.slice(1) : query);
+    topParams.delete('limit');
+    const topQuery = topParams.toString();
+    fetch(`/datos_top_numeros?limit=3${topQuery ? '&' + topQuery : ''}`)
       .then(response => response.json())
       .then(data => {
         const labels = data.map(item => item.numero);
         const values = data.map(item => item.mensajes);
+
+        const tablaTop = document.getElementById('tabla_top_numeros');
+        if (tablaTop) {
+          const tbody = tablaTop.querySelector('tbody');
+          tbody.innerHTML = '';
+          data.forEach(item => {
+            const row = document.createElement('tr');
+            const numCell = document.createElement('td');
+            numCell.textContent = item.numero;
+            const msgCell = document.createElement('td');
+            msgCell.textContent = item.mensajes;
+            row.appendChild(numCell);
+            row.appendChild(msgCell);
+            tbody.appendChild(row);
+          });
+        }
+
         if (chartTopNumeros) chartTopNumeros.destroy();
         const ctx = document.getElementById('graficoTopNumeros').getContext('2d');
         chartTopNumeros = new Chart(ctx, {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -67,6 +67,15 @@
             <div class="card">
                 <h4>Top Números</h4>
                 <canvas id="graficoTopNumeros" height="120"></canvas>
+                <table id="tabla_top_numeros">
+                    <thead>
+                        <tr>
+                            <th>Número</th>
+                            <th>Mensajes</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
             </div>
             <div class="card">
                 <h4>Palabras Más Usadas</h4>


### PR DESCRIPTION
## Summary
- Show only top three numbers by requesting `/datos_top_numeros?limit=3` and rendering them in a new table
- Add table in tablero template to list numbers with their message counts
- Default `limit` param to 3 on `/datos_top_numeros` route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b313945ba483239255cb706944923e