### PR TITLE
Show top word frequencies on dashboard

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -221,11 +221,31 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       });
 
-    fetch(`/datos_palabras${query}`)
+    const palabrasParams = new URLSearchParams(query.startsWith('?') ? query.slice(1) : query);
+    palabrasParams.set('limit', 5);
+    const palabrasQuery = palabrasParams.toString();
+    fetch(`/datos_palabras?${palabrasQuery}`)
       .then(response => response.json())
       .then(data => {
         const labels = data.map(item => item.palabra);
         const values = data.map(item => item.frecuencia);
+
+        const tablaPalabras = document.getElementById('tabla_palabras');
+        if (tablaPalabras) {
+          const tbody = tablaPalabras.querySelector('tbody');
+          tbody.innerHTML = '';
+          data.forEach(item => {
+            const row = document.createElement('tr');
+            const palabraCell = document.createElement('td');
+            palabraCell.textContent = item.palabra;
+            const freqCell = document.createElement('td');
+            freqCell.textContent = item.frecuencia;
+            row.appendChild(palabraCell);
+            row.appendChild(freqCell);
+            tbody.appendChild(row);
+          });
+        }
+
         if (chartPalabras) chartPalabras.destroy();
         const ctx = document.getElementById('grafico_palabras').getContext('2d');
         chartPalabras = new Chart(ctx, {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -80,6 +80,15 @@
             <div class="card">
                 <h4>Palabras Más Usadas</h4>
                 <canvas id="grafico_palabras" height="120"></canvas>
+                <table id="tabla_palabras">
+                    <thead>
+                        <tr>
+                            <th>Palabra</th>
+                            <th>Frecuencia</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
             </div>
             <div class="card">
                 <h4>Roles</h4>


### PR DESCRIPTION
## Summary
- Add table to dashboard for top words
- Fetch word data with limit and fill table alongside word cloud

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b31434ea648323bc15b810ad221d64