### PR TITLE
Agrupa tipos de mensajes en tablero

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -226,7 +226,23 @@ def datos_tipos():
     rows = cur.fetchall()
     conn.close()
 
-    data = [{"tipo": tipo or "desconocido", "total": count} for tipo, count in rows]
+    aggregates = {"cliente": 0, "bot": 0, "asesor": 0, "otros": 0}
+    for tipo, count in rows:
+        t = (tipo or "").lower()
+        if t.startswith("cliente"):
+            aggregates["cliente"] += count
+        elif t.startswith("bot"):
+            aggregates["bot"] += count
+        elif t.startswith("asesor"):
+            aggregates["asesor"] += count
+        else:
+            aggregates["otros"] += count
+
+    data = [
+        {"tipo": tipo, "total": total}
+        for tipo, total in aggregates.items()
+        if total > 0
+    ]
     return jsonify(data)
 
 

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -307,18 +307,29 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch(`/datos_tipos${query}`)
       .then(response => response.json())
       .then(data => {
-        const labels = data.map(item => item.tipo);
-        const values = data.map(item => item.total);
+        const order = ['cliente', 'bot', 'asesor', 'otros'];
+        const labelMap = { cliente: 'Clientes', bot: 'Bots', asesor: 'Asesores', otros: 'Otros' };
+        const colorMap = { cliente: '#FF6384', bot: '#36A2EB', asesor: '#FFCE56', otros: '#4BC0C0' };
+        const labels = [];
+        const values = [];
+        const colors = [];
+        order.forEach(cat => {
+          const entry = data.find(d => d.tipo === cat);
+          if (entry) {
+            labels.push(labelMap[cat]);
+            values.push(entry.total);
+            colors.push(colorMap[cat]);
+          }
+        });
         if (chartTipos) chartTipos.destroy();
         const ctx = document.getElementById('graficoTipos').getContext('2d');
-        const colors = ['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40','#8E5EA2','#3CBA9F','#E8C3B9','#C45850'];
         chartTipos = new Chart(ctx, {
           type: 'doughnut',
           data: {
             labels: labels,
             datasets: [{
               data: values,
-              backgroundColor: labels.map((_, i) => colors[i % colors.length])
+              backgroundColor: colors
             }]
           },
           options: {


### PR DESCRIPTION
## Summary
- Agrupa tipos de mensajes en `/datos_tipos` en categorías: cliente, bot, asesor y otros
- Ajusta `tablero.js` para graficar únicamente estas categorías

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `node --check static/tablero.js`


------
https://chatgpt.com/codex/tasks/task_e_68b314d10f3c8323a6d87dee5b9431c4