### PR TITLE
Add daily message type metrics

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const REFRESH_INTERVAL = 60000;
-  let chartTotales, chartDiario, chartHora, chartTablero, chartTopNumeros, chartPalabras, chartRoles, chartTipos;
+  let chartTotales, chartDiario, chartHora, chartTablero, chartTopNumeros, chartPalabras, chartRoles, chartTipos, chartTiposDiarios;
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false }
@@ -334,6 +334,50 @@ document.addEventListener('DOMContentLoaded', () => {
           },
           options: {
             ...commonOptions
+          }
+        });
+      });
+
+    fetch(`/datos_tipos_diarios${query}`)
+      .then(response => response.json())
+      .then(data => {
+        const labels = data.map(item => item.fecha);
+        const datasets = [
+          {
+            label: 'Clientes',
+            data: data.map(item => item.cliente || 0),
+            borderColor: '#FF6384',
+            backgroundColor: 'rgba(255, 99, 132, 0.2)',
+            tension: 0.1,
+            fill: false
+          },
+          {
+            label: 'Bots',
+            data: data.map(item => item.bot || 0),
+            borderColor: '#36A2EB',
+            backgroundColor: 'rgba(54, 162, 235, 0.2)',
+            tension: 0.1,
+            fill: false
+          },
+          {
+            label: 'Asesores',
+            data: data.map(item => item.asesor || 0),
+            borderColor: '#FFCE56',
+            backgroundColor: 'rgba(255, 206, 86, 0.2)',
+            tension: 0.1,
+            fill: false
+          }
+        ];
+        if (chartTiposDiarios) chartTiposDiarios.destroy();
+        const ctx = document.getElementById('graficoTiposDiarios').getContext('2d');
+        chartTiposDiarios = new Chart(ctx, {
+          type: 'line',
+          data: { labels, datasets },
+          options: {
+            ...commonOptions,
+            scales: {
+              y: { beginAtZero: true }
+            }
           }
         });
       });

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -107,6 +107,10 @@
                 <h4>Tipos de Mensaje</h4>
                 <canvas id="graficoTipos" height="120"></canvas>
             </div>
+            <div class="card">
+                <h4>Tipos por Día</h4>
+                <canvas id="graficoTiposDiarios" height="120"></canvas>
+            </div>
         </section>
     </div>
 </main>


### PR DESCRIPTION
## Summary
- add `/datos_tipos_diarios` API returning message counts per type for each day
- plot client, bot and advisor daily counts in a new multi-line chart
- show the chart on the dashboard reports section

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `node --check static/tablero.js`


------
https://chatgpt.com/codex/tasks/task_e_68b31567f4188323aeebde123e2e2a1b