### PR TITLE
Add role and number filters to dashboard

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -157,3 +157,18 @@
 .filters-panel.open {
   max-height: 500px;
 }
+
+.filters-panel label,
+.filters-panel input,
+.filters-panel select,
+.filters-panel button {
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.filters-panel .message-type {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -19,6 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const filtersToggle = document.getElementById('filters-toggle');
   const filtersPanel = document.querySelector('.filters-panel');
   const applyFilters = document.getElementById('apply-filters');
+  const filtroRol = document.getElementById('filtroRol');
+  const filtroNumero = document.getElementById('filtroNumero');
+  const clearFilters = document.getElementById('clear-filters');
+  const tipoCliente = document.getElementById('tipoCliente');
+  const tipoBot = document.getElementById('tipoBot');
+  const tipoAsesor = document.getElementById('tipoAsesor');
 
   if (filtersToggle && filtersPanel) {
     filtersToggle.addEventListener('click', () => {
@@ -33,11 +39,61 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  if (clearFilters) {
+    clearFilters.addEventListener('click', () => {
+      if (startInput) startInput.value = '';
+      if (endInput) endInput.value = '';
+      if (limitInput) limitInput.value = '10';
+      if (filtroRol) filtroRol.selectedIndex = 0;
+      if (filtroNumero) filtroNumero.selectedIndex = 0;
+      [tipoCliente, tipoBot, tipoAsesor].forEach(cb => {
+        if (cb) cb.checked = true;
+      });
+      cargarDatos();
+    });
+  }
+
+  function populateFilters() {
+    if (filtroRol) {
+      fetch('/datos_roles')
+        .then(res => res.json())
+        .then(data => {
+          filtroRol.innerHTML = '<option value="">Todos</option>';
+          data.forEach(item => {
+            const opt = document.createElement('option');
+            opt.value = item.rol;
+            opt.textContent = item.rol;
+            filtroRol.appendChild(opt);
+          });
+        });
+    }
+    if (filtroNumero) {
+      fetch('/datos_tablero')
+        .then(res => res.json())
+        .then(data => {
+          filtroNumero.innerHTML = '<option value="">Todos</option>';
+          data.forEach(item => {
+            const opt = document.createElement('option');
+            opt.value = item.numero;
+            opt.textContent = item.numero;
+            filtroNumero.appendChild(opt);
+          });
+        });
+    }
+  }
+
   function buildQuery() {
     const params = new URLSearchParams();
     if (startInput.value) params.append('start', startInput.value);
     if (endInput.value) params.append('end', endInput.value);
     if (limitInput && limitInput.value) params.append('limit', limitInput.value);
+    if (filtroRol && filtroRol.value) params.append('rol', filtroRol.value);
+    if (filtroNumero && filtroNumero.value) params.append('numero', filtroNumero.value);
+    const tipos = [];
+    if (tipoCliente && tipoCliente.checked) tipos.push('cliente');
+    if (tipoBot && tipoBot.checked) tipos.push('bot');
+    if (tipoAsesor && tipoAsesor.checked) tipos.push('asesor');
+    if (tipos.length && tipos.length < 3) params.append('tipos', tipos.join(','));
     const q = params.toString();
     return q ? `?${q}` : '';
   }
@@ -383,6 +439,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   }
 
+  populateFilters();
   cargarDatos();
   setInterval(cargarDatos, REFRESH_INTERVAL);
 });

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -23,7 +23,22 @@
     <input type="date" id="fechaFin">
     <label for="limit">Límite de palabras:</label>
     <input type="number" id="limit" min="1" value="10">
+    <label for="filtroRol">Rol:</label>
+    <select id="filtroRol">
+        <option value="">Todos</option>
+    </select>
+    <label for="filtroNumero">Número:</label>
+    <select id="filtroNumero">
+        <option value="">Todos</option>
+    </select>
+    <div class="message-type">
+        <span>Tipo:</span>
+        <label><input type="checkbox" id="tipoCliente" value="cliente" checked> Cliente</label>
+        <label><input type="checkbox" id="tipoBot" value="bot" checked> Bot</label>
+        <label><input type="checkbox" id="tipoAsesor" value="asesor" checked> Asesor</label>
+    </div>
     <button id="apply-filters">Aplicar</button>
+    <button id="clear-filters" type="button">Limpiar filtros</button>
 </div>
 
 <nav class="sidebar">


### PR DESCRIPTION
## Summary
- add role and number dropdown filters with message type checkboxes and reset action
- style filter panel items for spacing and flex layout
- populate filter options and integrate selections into dashboard queries

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b317199fd8832388b2d9ade5bbbeaa