### PR TITLE
Remove legacy sidebar and header from dashboard

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -1,68 +1,3 @@
-.header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 60px;
-  background: var(--bg-glass);
-  color: var(--text-light);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 1rem;
-  z-index: 1000;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255,255,255,0.2);
-  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
-}
-
-#menu-toggle {
-  background: none;
-  border: none;
-  color: var(--accent-neon);
-  font-size: 1.5rem;
-  cursor: pointer;
-  transition: color 0.3s;
-}
-#menu-toggle:hover {
-  color: var(--accent-hover);
-}
-
-.sidebar {
-  position: fixed;
-  top: 60px;
-  left: 0;
-  width: 220px;
-  height: calc(100% - 60px);
-  background: var(--bg-sidebar);
-  overflow-y: auto;
-  transition: transform 0.3s ease;
-}
-
-.sidebar ul {
-  list-style: none;
-}
-
-.sidebar li a {
-  display: block;
-  padding: 1rem;
-  color: var(--accent-neon);
-  text-decoration: none;
-  transition: color 0.3s, background 0.3s;
-}
-
-.sidebar li a:hover {
-  background: var(--accent-neon);
-  color: var(--text-light);
-}
-
-.content {
-  margin-top: 60px;
-  margin-left: 220px;
-  padding: 20px;
-  transition: margin-left 0.3s ease;
-}
-
 .dashboard-grid {
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -128,18 +63,6 @@
 }
 
 @media (max-width: 768px) {
-  .sidebar {
-    transform: translateX(-100%);
-  }
-
-  .sidebar.open {
-    transform: translateX(0);
-  }
-
-  .content {
-    margin-left: 0;
-  }
-
   .dashboard-grid {
     grid-template-columns: 1fr;
     grid-template-areas:

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -5,14 +5,6 @@ document.addEventListener('DOMContentLoaded', () => {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false }
   };
-  const menuToggle = document.getElementById('menu-toggle');
-  const sidebar = document.querySelector('.sidebar');
-  if (menuToggle && sidebar) {
-    menuToggle.addEventListener('click', () => {
-      sidebar.classList.toggle('open');
-    });
-  }
-
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');
   const limitInput = document.getElementById('limit');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -10,10 +10,6 @@
     </a>
 </div>
 
-<header class="header">
-    <button id="menu-toggle">☰</button>
-    <h1>Tablero</h1>
-</header>
 
 <button id="filters-toggle" class="filters-toggle">Filtros</button>
 <div class="filters-panel">
@@ -41,12 +37,6 @@
     <button id="clear-filters" type="button">Limpiar filtros</button>
 </div>
 
-<nav class="sidebar">
-    <ul>
-        <li><a href="#totalesCard">Totales</a></li>
-        <li><a href="#reportes">Reportes</a></li>
-    </ul>
-</nav>
 
 <main class="content">
     <div class="dashboard-grid">


### PR DESCRIPTION
## Summary
- drop dashboard header and sidebar markup
- remove unused sidebar/header styles and JS toggling

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b31b2289a083239e8e2c2259e29058