### PR TITLE
Improve dashboard responsiveness

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -1,8 +1,8 @@
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 1fr 2fr;
   gap: 2rem;
   margin: 2rem;
+  grid-template-columns: 1fr;
 }
 
 .totales {
@@ -13,17 +13,15 @@
   grid-area: graficas;
 }
 
-.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 20px;
-  margin-bottom: 20px;
-}
-
+.cards,
 .reports {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
+  grid-template-columns: 1fr;
+}
+
+.cards {
+  margin-bottom: 20px;
 }
 
 .card {
@@ -50,24 +48,23 @@
   height: auto;
 }
 
-@media (max-width: 1024px) {
+@media (min-width: 768px) {
   .dashboard-grid {
     grid-template-columns: 1fr 1fr;
   }
+
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  }
+
+  .reports {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  }
 }
 
-@media (max-width: 900px) {
-    .dashboard-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-@media (max-width: 768px) {
+@media (min-width: 1200px) {
   .dashboard-grid {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "totales"
-      "graficas";
+    grid-template-columns: 1fr 2fr;
   }
 }
 

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -38,7 +38,7 @@
 </div>
 
 
-<main class="content">
+<main>
     <div class="dashboard-grid">
         <section class="cards totales">
             <div class="card">


### PR DESCRIPTION
## Summary
- remove obsolete `content` wrapper in dashboard template
- make dashboard grid mobile-first with responsive columns
- ensure card and report sections layout responsively

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b31bfaa2848323b16a85bc9db2ea77