### PR TITLE
Ensure dashboard elements fill available width

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -3,7 +3,7 @@
   gap: 2rem;
   margin: 2rem;
   grid-template-columns: 1fr;
-  justify-items: center;
+  justify-items: stretch;
 }
 
 .totales {
@@ -19,6 +19,7 @@
   display: grid;
   gap: 20px;
   grid-template-columns: 1fr;
+  width: 100%;
 }
 
 .cards {
@@ -26,7 +27,7 @@
 }
 
 .reports {
-  justify-items: center;
+  justify-items: stretch;
 }
 
 .card {
@@ -38,6 +39,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 }
 
 .card h3, .card h4 {
@@ -53,7 +55,6 @@
 .card canvas {
   width: 100%;
   height: 400px;
-  max-width: 90%;
   display: block;
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- Stretch dashboard and report items to occupy full container width
- Set cards and reports grids to full width and expanded card content
- Allow dashboard charts to use entire card width

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3233ad8f08323ba289b389685e805