### PR TITLE
Improve reports grid flexibility

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -19,6 +19,7 @@
   display: grid;
   gap: 20px;
   grid-template-columns: 1fr;
+  grid-auto-flow: dense;
   width: 100%;
 }
 
@@ -69,7 +70,7 @@
   }
 
   .reports {
-    grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- Use `minmax(300px, 1fr)` for report cards grid
- Apply `grid-auto-flow: dense` to evenly distribute cards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b32487b58c83239e32d4457cc3c63d