### PR TITLE
Handle fetch errors on dashboard

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -104,3 +104,9 @@
   flex-wrap: wrap;
   gap: 0.5rem;
 }
+
+.card-message {
+  color: red;
+  margin-top: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- Add showCardMessage helper and chain `.catch` to dashboard fetches
- Display user-friendly messages when data requests fail or return empty
- Style card message indicator

## Testing
- `node --check static/tablero.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3252d84fc8323aaef4a1ad526722a