### PR TITLE
Ajusta botón de edición y color del menú

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -89,7 +89,7 @@
     }
     #settingsMenu a {
       padding:8px 12px; text-decoration:none;
-      color:var(--accent-neon); font-size:14px;
+      color:#000; font-size:14px;
       transition:background 0.3s, color 0.3s;
     }
     #settingsMenu a:hover {
@@ -400,6 +400,20 @@
     }
     .delete-btn:hover {
       background: var(--accent-hover);
+    }
+
+    .action-buttons {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .action-form {
+      background: var(--text-light);
+      border-radius: 8px;
+      padding: 10px;
+      margin: 0;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     }
 
     .top-right {

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -112,10 +112,14 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td>
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
-            <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
-                <button class="delete-btn btn-primary" type="submit">Eliminar</button>
-            </form>
+            <div class="action-buttons">
+                <form class="action-form" onsubmit="return false;">
+                    <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+                </form>
+                <form class="action-form" method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
+                    <button class="delete-btn btn-primary" type="submit">Eliminar</button>
+                </form>
+            </div>
         </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Resumen
- Muestra el botón Editar en un recuadro separado, colocado sobre Eliminar en la tabla de reglas.
- Cambia el color de las opciones del menú del engranaje a negro.
- Agrega estilos para contenedor de acciones en reglas.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4731fa30883239e7368f74f735e91