### PR TITLE
Align rule edit button and white settings background

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -35,6 +35,8 @@
     }
     body.page {
       padding: 20px;
+      background: #fff;
+      background-image: none;
     }
     .container {
       flex: 1;
@@ -389,17 +391,29 @@
       padding: 10px;
       text-align: left;
     }
-    .delete-btn {
-      background: var(--accent-neon);
-      color: var(--text-light);
-      border: none;
+    .delete-btn,
+    .edit-btn {
+      background: #fff;
+      color: var(--accent-neon);
+      border: 1px solid var(--accent-neon);
       padding: 6px 12px;
       border-radius: 4px;
       cursor: pointer;
       transition: background 0.3s, color 0.3s;
     }
-    .delete-btn:hover {
+    .delete-btn:hover,
+    .edit-btn:hover {
       background: var(--accent-hover);
+      color: var(--text-light);
+    }
+
+    .action-cell {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+    .action-cell form {
+      margin: 0;
     }
 
     .top-right {

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -111,7 +111,7 @@
         <td>{{ regla.footer or '-' }}</td>
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
-        <td>
+        <td class="action-cell">
             <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -111,7 +111,7 @@
         <td>{{ regla.footer or '-' }}</td>
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
-        <td>
+        <td class="action-cell">
             <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>


### PR DESCRIPTION
## Summary
- Style edit and delete buttons with a white square and horizontal alignment
- Ensure configuration pages use a white background for consistency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a02d65b88323a52b4760e74e85a8