### PR TITLE
Adjust action-cell styling for full width action buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -400,6 +400,8 @@
       border-radius: 4px;
       cursor: pointer;
       transition: background 0.3s, color 0.3s;
+      display: block;
+      width: 100%;
     }
     .delete-btn:hover,
     .edit-btn:hover {
@@ -409,11 +411,13 @@
 
     .action-cell {
       display: flex;
+      flex-direction: column;
       gap: 8px;
-      align-items: center;
+      align-items: stretch;
     }
     .action-cell form {
       margin: 0;
+      width: 100%;
     }
 
     .top-right {


### PR DESCRIPTION
## Summary
- Ensure delete and edit buttons span full width and display as block
- Align action-cell items vertically and stretch forms to full width

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a3b86b308323a916bd462f794b97