### PR TITLE
Align edit button styling with delete button

### DIFF
--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -112,7 +112,9 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td class="action-cell">
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            <form onsubmit="event.preventDefault();">
+                <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            </form>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -112,7 +112,9 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td class="action-cell">
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            <form onsubmit="event.preventDefault();">
+                <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            </form>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>


### PR DESCRIPTION
## Summary
- Wrap "Editar" button in a form so it inherits the same white card styling and full-width layout as the "Eliminar" button.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a4d5e850832384d7442afa240c3a