### PR TITLE
Align edit button styling and organize dashboard stats

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -1,17 +1,9 @@
+
 .dashboard-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 2rem;
   margin: 2rem;
-  grid-template-columns: 1fr;
-  justify-items: stretch;
-}
-
-.totales {
-  grid-area: totales;
-}
-
-.graficas {
-  grid-area: graficas;
 }
 
 .cards,
@@ -55,28 +47,18 @@
 
 .card canvas {
   width: 100%;
-  height: 400px;
+  height: 300px;
   display: block;
   margin: 0 auto;
 }
 
 @media (min-width: 768px) {
-  .dashboard-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
   .cards {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
   .reports {
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  }
-}
-
-@media (min-width: 1200px) {
-  .dashboard-grid {
-    grid-template-columns: 1fr 2fr;
   }
 }
 

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -1,6 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const REFRESH_INTERVAL = 60000;
-  let chartTotales, chartDiario, chartHora, chartTablero, chartTopNumeros, chartPalabras, chartRoles, chartTipos, chartTiposDiarios;
+  let chartTotales,
+      chartDiario,
+      chartHora,
+      chartTablero,
+      chartTopNumeros,
+      chartPalabras,
+      chartRoles,
+      chartTipos,
+      chartTiposDiarios;
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -112,7 +112,9 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td class="action-cell">
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            <form onsubmit="event.preventDefault();">
+                <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            </form>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -112,7 +112,9 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td class="action-cell">
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            <form onsubmit="event.preventDefault();">
+                <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            </form>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -40,7 +40,7 @@
 
 <main>
     <div class="dashboard-grid">
-        <section class="cards totales">
+        <section class="cards resumen">
             <div class="card">
                 <h3>Total de mensajes</h3>
                 <p id="totalMensajes">0</p>
@@ -49,14 +49,20 @@
                 <h3>Cantidad de roles</h3>
                 <p id="cantidadRoles">0</p>
             </div>
-            <div class="card" id="totalesCard">
-                <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <p>Enviados: <span id="totalEnviados">0</span></p>
-                <p>Recibidos: <span id="totalRecibidos">0</span></p>
-                <canvas id="graficoTotales"></canvas>
+            <div class="card">
+                <h3>Enviados</h3>
+                <p id="totalEnviados">0</p>
+            </div>
+            <div class="card">
+                <h3>Recibidos</h3>
+                <p id="totalRecibidos">0</p>
             </div>
         </section>
-        <section class="reports graficas" id="reportes">
+        <section class="reports" id="reportes">
+            <div class="card">
+                <h3><span class="icon">📊</span> Totales de mensajes</h3>
+                <canvas id="graficoTotales"></canvas>
+            </div>
             <div class="card">
                 <h4>Mensajes por Día</h4>
                 <canvas id="graficoDiario"></canvas>


### PR DESCRIPTION
## Summary
- Wrap "Editar" button in a form so it inherits the same white card styling and full-width layout as the "Eliminar" button.
- Reorganize dashboard layout with summary statistic cards and updated chart grid styling.
- Clarify chart initialization by consolidating graph variables.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4d5e850832384d7442afa240c3a