### PR TITLE
Align edit button styling and organize dashboard stats

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -330,8 +330,8 @@ def datos_top_numeros():
     params.extend(filter_params)
     if conditions:
         query += " WHERE " + " AND ".join(conditions)
-    query += " GROUP BY m.numero ORDER BY total DESC LIMIT ?"
-    params.append(limite)
+    # Embed the limit directly to avoid placeholder compatibility issues
+    query += f" GROUP BY m.numero ORDER BY total DESC LIMIT {limite}"
     cur.execute(query, params)
     rows = cur.fetchall()
     conn.close()

--- a/static/tablero.css
+++ b/static/tablero.css
@@ -1,17 +1,9 @@
+
 .dashboard-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 2rem;
   margin: 2rem;
-  grid-template-columns: 1fr;
-  justify-items: stretch;
-}
-
-.totales {
-  grid-area: totales;
-}
-
-.graficas {
-  grid-area: graficas;
 }
 
 .cards,
@@ -55,18 +47,14 @@
 
 .card canvas {
   width: 100%;
-  height: 400px;
+  height: 300px;
   display: block;
   margin: 0 auto;
 }
 
 @media (min-width: 768px) {
-  .dashboard-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
   .cards {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
   .reports {
@@ -74,28 +62,33 @@
   }
 }
 
-@media (min-width: 1200px) {
-  .dashboard-grid {
-    grid-template-columns: 1fr 2fr;
-  }
+.filters-toggle {
+  margin: 1rem 0;
 }
 
 .filters-panel {
   max-height: 0;
   overflow: hidden;
-  transition: max-height 0.3s ease;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  padding: 0;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+  margin-bottom: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .filters-panel.open {
   max-height: 500px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
 }
 
-.filters-panel label,
-.filters-panel input,
-.filters-panel select,
-.filters-panel button {
-  margin-right: 0.5rem;
-  margin-bottom: 0.5rem;
+.filters-panel label {
+  font-weight: 600;
 }
 
 .filters-panel .message-type {

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -1,6 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const REFRESH_INTERVAL = 60000;
-  let chartTotales, chartDiario, chartHora, chartTablero, chartTopNumeros, chartPalabras, chartRoles, chartTipos, chartTiposDiarios;
+  let chartTotales,
+      chartDiario,
+      chartHora,
+      chartTablero,
+      chartTopNumeros,
+      chartPalabras,
+      chartRoles,
+      chartTipos,
+      chartTiposDiarios;
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
@@ -28,8 +36,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (applyFilters && filtersPanel) {
     applyFilters.addEventListener('click', () => {
       cargarDatos();
-      cargarRoles();
-      cargarNumeros();
       filtersPanel.classList.remove('open');
     });
   }
@@ -398,18 +404,22 @@ document.addEventListener('DOMContentLoaded', () => {
         showCardMessage('grafico_palabras');
         const ctx = document.getElementById('grafico_palabras').getContext('2d');
         chartPalabras = new Chart(ctx, {
-          type: 'wordCloud',
+          type: 'bar',
           data: {
             labels: labels,
             datasets: [{
-              label: 'Palabras más frecuentes',
-              data: values
+              label: 'Frecuencia',
+              data: values,
+              backgroundColor: 'rgba(153, 102, 255, 0.5)',
+              borderColor: 'rgba(153, 102, 255, 1)',
+              borderWidth: 1
             }]
           },
           options: {
             ...commonOptions,
-            plugins: {
-              legend: { display: false }
+            indexAxis: 'y',
+            scales: {
+              x: { beginAtZero: true }
             }
           }
         });

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -112,7 +112,9 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td class="action-cell">
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            <form onsubmit="event.preventDefault();">
+                <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            </form>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -112,7 +112,9 @@
         <td>{{ regla.calculo or '-' }}</td>
         <td>{{ regla.handler or '-' }}</td>
         <td class="action-cell">
-            <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            <form onsubmit="event.preventDefault();">
+                <button class="edit-btn btn-primary" type="button" onclick='cargarRegla({{ regla|tojson }})'>Editar</button>
+            </form>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla.id) }}">
                 <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -11,7 +11,7 @@
 </div>
 
 
-<button id="filters-toggle" class="filters-toggle">Filtros</button>
+<button id="filters-toggle" class="filters-toggle btn-primary">Filtros</button>
 <div class="filters-panel">
     <label for="fechaInicio">Desde:</label>
     <input type="date" id="fechaInicio">
@@ -33,14 +33,14 @@
         <label><input type="checkbox" id="tipoBot" value="bot" checked> Bot</label>
         <label><input type="checkbox" id="tipoAsesor" value="asesor" checked> Asesor</label>
     </div>
-    <button id="apply-filters">Aplicar</button>
-    <button id="clear-filters" type="button">Limpiar filtros</button>
+    <button id="apply-filters" class="btn-primary">Aplicar</button>
+    <button id="clear-filters" type="button" class="btn-primary">Limpiar filtros</button>
 </div>
 
 
 <main>
     <div class="dashboard-grid">
-        <section class="cards totales">
+        <section class="cards resumen">
             <div class="card">
                 <h3>Total de mensajes</h3>
                 <p id="totalMensajes">0</p>
@@ -49,14 +49,20 @@
                 <h3>Cantidad de roles</h3>
                 <p id="cantidadRoles">0</p>
             </div>
-            <div class="card" id="totalesCard">
-                <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <p>Enviados: <span id="totalEnviados">0</span></p>
-                <p>Recibidos: <span id="totalRecibidos">0</span></p>
-                <canvas id="graficoTotales"></canvas>
+            <div class="card">
+                <h3>Enviados</h3>
+                <p id="totalEnviados">0</p>
+            </div>
+            <div class="card">
+                <h3>Recibidos</h3>
+                <p id="totalRecibidos">0</p>
             </div>
         </section>
-        <section class="reports graficas" id="reportes">
+        <section class="reports" id="reportes">
+            <div class="card">
+                <h3><span class="icon">📊</span> Totales de mensajes</h3>
+                <canvas id="graficoTotales"></canvas>
+            </div>
             <div class="card">
                 <h4>Mensajes por Día</h4>
                 <canvas id="graficoDiario"></canvas>
@@ -121,7 +127,6 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-wordcloud"></script>
 <script src="{{ url_for('static', filename='tablero.js') }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Wrap "Editar" button in a form so it inherits the same white card styling and full-width layout as the "Eliminar" button.
- Reorganize dashboard layout with summary statistic cards and updated chart grid styling.
- Clarify chart initialization by consolidating graph variables.
- Fix top-n numbers query and switch word statistics to bar chart for reliable rendering.
- Style and fix the dashboard filter panel; applying filters no longer resets selections.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4d5e850832384d7442afa240c3a