### PR TITLE
Use MySQL-style placeholders in tablero queries

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -15,18 +15,18 @@ def _apply_filters(cur, rol, numero):
     params = []
 
     if numero:
-        cur.execute("SELECT 1 FROM mensajes WHERE numero = ? LIMIT 1", (numero,))
+        cur.execute("SELECT 1 FROM mensajes WHERE numero = %s LIMIT 1", (numero,))
         if not cur.fetchone():
             raise ValueError("numero")
-        conditions.append("m.numero = ?")
+        conditions.append("m.numero = %s")
         params.append(numero)
 
     if rol:
-        cur.execute("SELECT 1 FROM roles WHERE id = ?", (rol,))
+        cur.execute("SELECT 1 FROM roles WHERE id = %s", (rol,))
         if not cur.fetchone():
             raise ValueError("rol")
         joins.append("JOIN chat_roles AS cr ON m.numero = cr.numero")
-        conditions.append("cr.role_id = ?")
+        conditions.append("cr.role_id = %s")
         params.append(rol)
 
     return " ".join(joins), conditions, params
@@ -99,7 +99,7 @@ def datos_tablero():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -152,7 +152,7 @@ def datos_tipos_diarios():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -214,7 +214,7 @@ def datos_palabras():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -251,12 +251,12 @@ def datos_roles():
     cur = conn.cursor()
 
     if numero:
-        cur.execute("SELECT 1 FROM mensajes WHERE numero = ? LIMIT 1", (numero,))
+        cur.execute("SELECT 1 FROM mensajes WHERE numero = %s LIMIT 1", (numero,))
         if not cur.fetchone():
             conn.close()
             return jsonify({"error": "Número no encontrado"}), 400
     if rol:
-        cur.execute("SELECT 1 FROM roles WHERE id = ?", (rol,))
+        cur.execute("SELECT 1 FROM roles WHERE id = %s", (rol,))
         if not cur.fetchone():
             conn.close()
             return jsonify({"error": "Rol no encontrado"}), 400
@@ -272,13 +272,13 @@ def datos_roles():
     )
     params = []
     if start and end:
-        query += " AND m.timestamp BETWEEN ? AND ?"
+        query += " AND m.timestamp BETWEEN %s AND %s"
         params.extend([start, end])
     if numero:
-        query += " AND m.numero = ?"
+        query += " AND m.numero = %s"
         params.append(numero)
     if rol:
-        query += " AND cr.role_id = ?"
+        query += " AND cr.role_id = %s"
         params.append(rol)
     query += " GROUP BY rol"
     cur.execute(query, params)
@@ -324,7 +324,7 @@ def datos_top_numeros():
     conditions = ["m.tipo LIKE 'cliente%'"]
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -373,7 +373,7 @@ def datos_mensajes_diarios():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -421,7 +421,7 @@ def datos_mensajes_hora():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -464,7 +464,7 @@ def datos_tipos():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)
@@ -523,7 +523,7 @@ def datos_totales():
     conditions = []
     params = []
     if start and end:
-        conditions.append("m.timestamp BETWEEN ? AND ?")
+        conditions.append("m.timestamp BETWEEN %s AND %s")
         params.extend([start, end])
     conditions.extend(filter_conditions)
     params.extend(filter_params)


### PR DESCRIPTION
## Summary
- Replace legacy `?` SQL placeholders with MySQL `%s` placeholders in tablero routes
- Update filter helper and all statistic queries to use `%s`

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `python - <<'PY'
from flask import Flask
from routes.tablero_routes import tablero_bp
from unittest.mock import patch
from datetime import datetime

class FakeCursor:
    def execute(self, query, params=None):
        self.query = query
        self.params = params
        if 'SELECT 1 FROM mensajes' in query or 'SELECT 1 FROM roles' in query:
            self._result = [(1,)]
        elif 'SELECT m.numero, m.mensaje' in query:
            self._result = [('123', 'hola mundo')]
        elif 'SELECT DATE(m.timestamp) AS fecha, m.tipo, COUNT(*)' in query:
            self._result = [(datetime(2024,1,1), 'cliente', 1)]
        else:
            self._result = []
    def fetchone(self):
        return self._result[0] if self._result else None
    def fetchall(self):
        return self._result

class FakeConn:
    def cursor(self):
        return FakeCursor()
    def close(self):
        pass

app = Flask(__name__)
app.secret_key='test'
app.register_blueprint(tablero_bp)

with patch('routes.tablero_routes.get_connection', return_value=FakeConn()):
    with app.test_client() as client:
        with client.session_transaction() as sess:
            sess['user'] = 'tester'
        print('datos_tablero', client.get('/datos_tablero?start=2024-01-01&end=2024-01-02&rol=1&numero=123').json)
        print('datos_tipos_diarios', client.get('/datos_tipos_diarios?start=2024-01-01&end=2024-01-02&rol=1&numero=123').json)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b5af7cbc388323a3523195dd5500a8