### PR TITLE
Add weekly message summary with new API and table

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -224,6 +224,31 @@ document.addEventListener('DOMContentLoaded', () => {
         showCardMessage('graficoDiario', 'Error al cargar datos');
       });
 
+    fetch(`/datos_mensajes_semana${query}`)
+      .then(response => response.json())
+      .then(data => {
+        const tabla = document.getElementById('tabla_dia_semana');
+        if (!tabla) return;
+        const tbody = tabla.querySelector('tbody');
+        tbody.innerHTML = '';
+        if (!Array.isArray(data) || data.length === 0) return;
+        data.forEach(item => {
+          const row = document.createElement('tr');
+          const diaCell = document.createElement('td');
+          diaCell.textContent = item.dia;
+          const totalCell = document.createElement('td');
+          totalCell.textContent = item.total;
+          row.appendChild(diaCell);
+          row.appendChild(totalCell);
+          tbody.appendChild(row);
+        });
+      })
+      .catch(err => {
+        console.error(err);
+        const tabla = document.getElementById('tabla_dia_semana');
+        if (tabla) tabla.querySelector('tbody').innerHTML = '';
+      });
+
     fetch(`/datos_mensajes_hora${query}`)
       .then(response => response.json())
       .then(data => {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -66,6 +66,10 @@
             <div class="card">
                 <h4>Mensajes por Día</h4>
                 <canvas id="graficoDiario"></canvas>
+                <table id="tabla_dia_semana">
+                    <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
+                    <tbody></tbody>
+                </table>
             </div>
             <div class="card">
                 <h4>Mensajes por Hora</h4>


### PR DESCRIPTION
## Summary
- add `/datos_mensajes_semana` backend endpoint to aggregate messages by weekday using existing filters
- display a new table under "Mensajes por Día" with weekday message totals
- fetch weekly data on dashboard load and populate the new table

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b4161bf48323bfbb34a81292c73f