### PR TITLE
Arrange day and hour message charts side by side

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -52,6 +52,25 @@
   margin: 0 auto;
 }
 
+.wide-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.large-chart {
+  grid-column: span 1;
+}
+
+.large-chart canvas {
+  height: 400px;
+}
+
+.wide-row .card canvas {
+  width: 100%;
+  height: 400px;
+}
+
 @media (min-width: 768px) {
   .cards {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -212,6 +212,7 @@ document.addEventListener('DOMContentLoaded', () => {
           },
           options: {
             ...commonOptions,
+            maintainAspectRatio: false,
             scales: {
               y: { beginAtZero: true }
             }
@@ -280,6 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
           },
           options: {
             ...commonOptions,
+            maintainAspectRatio: false,
             scales: {
               y: { beginAtZero: true }
             }

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -63,17 +63,19 @@
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
                 <canvas id="graficoTotales"></canvas>
             </div>
-            <div class="card">
-                <h4>Mensajes por Día</h4>
-                <canvas id="graficoDiario"></canvas>
-                <table id="tabla_dia_semana">
-                    <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
-                    <tbody></tbody>
-                </table>
-            </div>
-            <div class="card">
-                <h4>Mensajes por Hora</h4>
-                <canvas id="graficoHora"></canvas>
+            <div class="wide-row">
+                <div class="card large-chart">
+                    <h4>Mensajes por Día</h4>
+                    <canvas id="graficoDiario"></canvas>
+                    <table id="tabla_dia_semana">
+                        <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+                <div class="card">
+                    <h4>Mensajes por Hora</h4>
+                    <canvas id="graficoHora"></canvas>
+                </div>
             </div>
             <div class="card">
                 <h4>Mensajes por Usuario</h4>


### PR DESCRIPTION
## Summary
- Wrap day and hour message charts in a `wide-row` grid and enlarge the daily chart
- Add CSS grid styles for `wide-row` and `large-chart`, boosting chart heights for better visibility
- Disable aspect ratio constraints on daily and hourly charts to respect new sizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b4f1cc1c83239a119ea9c64502c2