### PR TITLE
Adjust canvas height on dashboard

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -47,7 +47,7 @@
 
 .card canvas {
   width: 100%;
-  height: 300px;
+  height: 150px;
   display: block;
   margin: 0 auto;
 }
@@ -61,7 +61,7 @@
 
 /* ajustar la altura para que la fila no se vea tan larga */
 .wide-row .card canvas {
-  height: 250px; /* o el valor que se prefiera */
+  height: 150px; /* o el valor que se prefiera */
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- shrink dashboard card canvas height to 150px for normal and wide row layouts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5bb2c72148323adbfcec30cad1f0d