### PR TITLE
Agrega scroll vertical a tablas del tablero

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -118,3 +118,9 @@
   margin-top: 1rem;
   text-align: center;
 }
+
+.card table {
+  max-height: 150px;
+  overflow-y: auto;
+  display: block;
+}


### PR DESCRIPTION
## Resumen
- Limita la altura de las tablas dentro de tarjetas del tablero y habilita barra de desplazamiento vertical
- Asegura que las tablas de estadísticas se mantengan dentro de un contenedor visible

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf70457c8323b8f1c866e1953f45