### PR TITLE
Limit report grid to four columns

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -75,7 +75,7 @@
   }
 
   .reports {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- Constrain report section to a four-column grid on large screens for better layout control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5c04155f48323acbd4fbd60977c09