### PR TITLE
Make dashboard charts responsive

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -32,7 +32,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
+  width: fit-content;
 }
 
 .card h3, .card h4 {
@@ -45,9 +45,10 @@
   margin-right: 0.5em;
 }
 
+
 .card canvas {
-  width: 280px !important;
-  height: 180px !important;
+  width: 100%;
+  height: 100%;
   display: block;
   margin: 0 auto;
 }
@@ -60,7 +61,7 @@
 }
 
 /* ajustar la altura para que la fila no se vea tan larga */
-.wide-row .card canvas {
+.wide-row .card {
   height: 150px; /* o el valor que se prefiera */
 }
 

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
     maintainAspectRatio: false,
-    responsive: false
+    responsive: true
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -61,12 +61,12 @@
         <section class="reports" id="reportes">
             <div class="card">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <canvas id="graficoTotales" width="280" height="180"></canvas>
+                <canvas id="graficoTotales"></canvas>
             </div>
             <div class="wide-row">
                 <div class="card">
                     <h4>Mensajes por Día</h4>
-                    <canvas id="graficoDiario" width="280" height="180"></canvas>
+                    <canvas id="graficoDiario"></canvas>
                     <table id="tabla_dia_semana">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
@@ -74,16 +74,16 @@
                 </div>
                 <div class="card">
                     <h4>Mensajes por Hora</h4>
-                    <canvas id="graficoHora" width="280" height="180"></canvas>
+                    <canvas id="graficoHora"></canvas>
                 </div>
             </div>
             <div class="card">
                 <h4>Mensajes por Usuario</h4>
-                <canvas id="grafico" width="280" height="180"></canvas>
+                <canvas id="grafico"></canvas>
             </div>
             <div class="card">
                 <h4>Top Números</h4>
-                <canvas id="graficoTopNumeros" width="280" height="180"></canvas>
+                <canvas id="graficoTopNumeros"></canvas>
                 <table id="tabla_top_numeros">
                     <thead>
                         <tr>
@@ -96,7 +96,7 @@
             </div>
             <div class="card">
                 <h4>Palabras Más Usadas</h4>
-                <canvas id="grafico_palabras" width="280" height="180"></canvas>
+                <canvas id="grafico_palabras"></canvas>
                 <table id="tabla_palabras">
                     <thead>
                         <tr>
@@ -109,7 +109,7 @@
             </div>
             <div class="card">
                 <h4>Roles</h4>
-                <canvas id="grafico_roles" width="280" height="180"></canvas>
+                <canvas id="grafico_roles"></canvas>
                 <table id="tabla_roles">
                     <thead>
                         <tr>
@@ -122,11 +122,11 @@
             </div>
             <div class="card">
                 <h4>Tipos de Mensaje</h4>
-                <canvas id="graficoTipos" width="280" height="180"></canvas>
+                <canvas id="graficoTipos"></canvas>
             </div>
             <div class="card">
                 <h4>Tipos por Día</h4>
-                <canvas id="graficoTiposDiarios" width="280" height="180"></canvas>
+                <canvas id="graficoTiposDiarios"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- Make dashboard cards auto-size with `fit-content`
- Remove fixed canvas sizes so charts fill their containers
- Enable Chart.js responsive mode

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5c45c699883238cbada66f7666e41