### PR TITLE
Ajusta tamaño estático de tarjetas de gráficos

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -32,7 +32,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: fit-content;
+}
+
+.chart-card {
+  width: 400px;
+  height: 300px;
 }
 
 .card h3, .card h4 {
@@ -58,11 +62,6 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 20px;
-}
-
-/* ajustar la altura para que la fila no se vea tan larga */
-.wide-row .card {
-  height: 150px; /* o el valor que se prefiera */
 }
 
 @media (max-width: 768px) {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -59,12 +59,12 @@
             </div>
         </section>
         <section class="reports" id="reportes">
-            <div class="card">
+            <div class="card chart-card">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
                 <canvas id="graficoTotales"></canvas>
             </div>
             <div class="wide-row">
-                <div class="card">
+                <div class="card chart-card">
                     <h4>Mensajes por Día</h4>
                     <canvas id="graficoDiario"></canvas>
                     <table id="tabla_dia_semana">
@@ -72,16 +72,16 @@
                         <tbody></tbody>
                     </table>
                 </div>
-                <div class="card">
+                <div class="card chart-card">
                     <h4>Mensajes por Hora</h4>
                     <canvas id="graficoHora"></canvas>
                 </div>
             </div>
-            <div class="card">
+            <div class="card chart-card">
                 <h4>Mensajes por Usuario</h4>
                 <canvas id="grafico"></canvas>
             </div>
-            <div class="card">
+            <div class="card chart-card">
                 <h4>Top Números</h4>
                 <canvas id="graficoTopNumeros"></canvas>
                 <table id="tabla_top_numeros">
@@ -94,7 +94,7 @@
                     <tbody></tbody>
                 </table>
             </div>
-            <div class="card">
+            <div class="card chart-card">
                 <h4>Palabras Más Usadas</h4>
                 <canvas id="grafico_palabras"></canvas>
                 <table id="tabla_palabras">
@@ -107,7 +107,7 @@
                     <tbody></tbody>
                 </table>
             </div>
-            <div class="card">
+            <div class="card chart-card">
                 <h4>Roles</h4>
                 <canvas id="grafico_roles"></canvas>
                 <table id="tabla_roles">
@@ -120,11 +120,11 @@
                     <tbody></tbody>
                 </table>
             </div>
-            <div class="card">
+            <div class="card chart-card">
                 <h4>Tipos de Mensaje</h4>
                 <canvas id="graficoTipos"></canvas>
             </div>
-            <div class="card">
+            <div class="card chart-card">
                 <h4>Tipos por Día</h4>
                 <canvas id="graficoTiposDiarios"></canvas>
             </div>


### PR DESCRIPTION
## Summary
- define clase `chart-card` con dimensiones fijas para las tarjetas de gráficos
- aplica `chart-card` a los contenedores de gráficos en `tablero.html`
- mantiene los lienzos de los gráficos ajustados al 100% del contenedor

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5c61f6ad08323b63b5d3bfc07e5b7