### PR TITLE
Disable chart responsiveness and enforce canvas sizing

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
     maintainAspectRatio: false,
-    responsive: true
+    responsive: false
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -61,12 +61,12 @@
         <section class="reports" id="reportes">
             <div class="card chart-card">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <canvas id="graficoTotales"></canvas>
+                <canvas id="graficoTotales" width="400" height="300"></canvas>
             </div>
             <div class="wide-row">
                 <div class="card chart-card">
                     <h4>Mensajes por Día</h4>
-                    <canvas id="graficoDiario"></canvas>
+                    <canvas id="graficoDiario" width="400" height="300"></canvas>
                     <table id="tabla_dia_semana">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
@@ -74,16 +74,16 @@
                 </div>
                 <div class="card chart-card">
                     <h4>Mensajes por Hora</h4>
-                    <canvas id="graficoHora"></canvas>
+                    <canvas id="graficoHora" width="400" height="300"></canvas>
                 </div>
             </div>
             <div class="card chart-card">
                 <h4>Mensajes por Usuario</h4>
-                <canvas id="grafico"></canvas>
+                <canvas id="grafico" width="400" height="300"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Top Números</h4>
-                <canvas id="graficoTopNumeros"></canvas>
+                <canvas id="graficoTopNumeros" width="400" height="300"></canvas>
                 <table id="tabla_top_numeros">
                     <thead>
                         <tr>
@@ -96,7 +96,7 @@
             </div>
             <div class="card chart-card">
                 <h4>Palabras Más Usadas</h4>
-                <canvas id="grafico_palabras"></canvas>
+                <canvas id="grafico_palabras" width="400" height="300"></canvas>
                 <table id="tabla_palabras">
                     <thead>
                         <tr>
@@ -109,7 +109,7 @@
             </div>
             <div class="card chart-card">
                 <h4>Roles</h4>
-                <canvas id="grafico_roles"></canvas>
+                <canvas id="grafico_roles" width="400" height="300"></canvas>
                 <table id="tabla_roles">
                     <thead>
                         <tr>
@@ -122,11 +122,11 @@
             </div>
             <div class="card chart-card">
                 <h4>Tipos de Mensaje</h4>
-                <canvas id="graficoTipos"></canvas>
+                <canvas id="graficoTipos" width="400" height="300"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Tipos por Día</h4>
-                <canvas id="graficoTiposDiarios"></canvas>
+                <canvas id="graficoTiposDiarios" width="400" height="300"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- set Chart.js responsive option to false in tablero
- define fixed width and height on tablero canvases for consistent sizing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c6f72fb88323aa65f0bec63a465b