### PR TITLE
Reorder daily/hourly report placement

### DIFF
--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -59,10 +59,6 @@
             </div>
         </section>
         <section class="reports" id="reportes">
-            <div class="card chart-card">
-                <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <canvas id="graficoTotales" width="400" height="300"></canvas>
-            </div>
             <div class="wide-row">
                 <div class="card chart-card">
                     <h4>Mensajes por Día</h4>
@@ -76,6 +72,10 @@
                     <h4>Mensajes por Hora</h4>
                     <canvas id="graficoHora" width="400" height="300"></canvas>
                 </div>
+            </div>
+            <div class="card chart-card">
+                <h3><span class="icon">📊</span> Totales de mensajes</h3>
+                <canvas id="graficoTotales" width="400" height="300"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Mensajes por Usuario</h4>


### PR DESCRIPTION
## Summary
- Move daily and hourly message reports to top of reports section for clearer layout
- Keep `.wide-row` spanning full grid width

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e496ee088323ba13060db625e297