### PR TITLE
Adjust chart card width to full container

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -41,7 +41,7 @@
 }
 
 .chart-card {
-  width: 450px;      /* Ajustar según necesidad */
+  width: 100%;
   height: 360px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Make chart cards stretch to the full width of their grid column while keeping fixed height
- Confirm dashboard's wide-row continues using two equal columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ⚠️ `pip install playwright` *(failed: Could not find a version that satisfies the requirement playwright)*


------
https://chatgpt.com/codex/tasks/task_e_68b5e6a391b48323be79e4c682c3cb2a