### PR TITLE
Improve dashboard chart layout responsiveness

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -43,7 +43,7 @@
 .chart-card {
   width: 100%;
   height: auto;
-  min-height: 360px;
+  min-height: 240px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -70,7 +70,8 @@
 }
 
 .chart-card canvas {
-  flex: 0 0 200px;   /* Gráfico fijo arriba */
+  flex: 0 0 150px;
+  height: 150px;
 }
 
 .chart-table {

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
     maintainAspectRatio: false,
-    responsive: false
+    responsive: true
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -62,7 +62,7 @@
             <div class="wide-row">
                 <div class="card chart-card">
                     <h4>Mensajes por Día</h4>
-                    <canvas id="graficoDiario" width="400" height="300"></canvas>
+                    <canvas id="graficoDiario"></canvas>
                     <table id="tabla_dia_semana">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
@@ -70,21 +70,21 @@
                 </div>
                 <div class="card chart-card">
                     <h4>Mensajes por Hora</h4>
-                    <canvas id="graficoHora" width="400" height="300"></canvas>
+                    <canvas id="graficoHora"></canvas>
                 </div>
             </div>
             <div class="card chart-card">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <canvas id="graficoTotales" width="400" height="300"></canvas>
+                <canvas id="graficoTotales"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Mensajes por Usuario</h4>
-                <canvas id="grafico" width="400" height="300"></canvas>
+                <canvas id="grafico"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Top Números</h4>
                 <div class="chart-table">
-                    <canvas id="graficoTopNumeros" width="400" height="300"></canvas>
+                    <canvas id="graficoTopNumeros"></canvas>
                     <table id="tabla_top_numeros">
                         <thead>
                             <tr>
@@ -99,7 +99,7 @@
             <div class="card chart-card">
                 <h4>Palabras Más Usadas</h4>
                 <div class="chart-table">
-                    <canvas id="grafico_palabras" width="400" height="300"></canvas>
+                    <canvas id="grafico_palabras"></canvas>
                     <table id="tabla_palabras">
                         <thead>
                             <tr>
@@ -114,7 +114,7 @@
             <div class="card chart-card">
                 <h4>Roles</h4>
                 <div class="chart-table">
-                    <canvas id="grafico_roles" width="400" height="300"></canvas>
+                    <canvas id="grafico_roles"></canvas>
                     <table id="tabla_roles">
                         <thead>
                             <tr>
@@ -128,11 +128,11 @@
             </div>
             <div class="card chart-card">
                 <h4>Tipos de Mensaje</h4>
-                <canvas id="graficoTipos" width="400" height="300"></canvas>
+                <canvas id="graficoTipos"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Tipos por Día</h4>
-                <canvas id="graficoTiposDiarios" width="400" height="300"></canvas>
+                <canvas id="graficoTiposDiarios"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- Reduce chart-card min-height and limit chart canvas height for better table visibility
- Remove fixed width/height attributes from dashboard canvases to rely on CSS sizing
- Enable responsive charts in common options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5eb57a6f48323af69209a73b2bb3c