### PR TITLE
Fix dashboard chart canvas sizing

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -63,15 +63,15 @@
 
 
 .card canvas {
-  width: 100%;
-  height: 100%;
+  width: 600px;
+  height: 300px;
   display: block;
   margin: 0 auto;
 }
 
 .chart-card canvas {
-  flex: 0 0 150px;
-  height: 150px;
+  width: 600px;
+  height: 300px;
 }
 
 .chart-table {

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
     maintainAspectRatio: false,
-    responsive: true
+    responsive: false
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -62,7 +62,7 @@
             <div class="wide-row">
                 <div class="card chart-card">
                     <h4>Mensajes por Día</h4>
-                    <canvas id="graficoDiario"></canvas>
+                    <canvas id="graficoDiario" width="600" height="300"></canvas>
                     <table id="tabla_dia_semana" class="fixed-table">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
@@ -70,21 +70,21 @@
                 </div>
                 <div class="card chart-card">
                     <h4>Mensajes por Hora</h4>
-                    <canvas id="graficoHora"></canvas>
+                    <canvas id="graficoHora" width="600" height="300"></canvas>
                 </div>
             </div>
             <div class="card chart-card">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <canvas id="graficoTotales"></canvas>
+                <canvas id="graficoTotales" width="600" height="300"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Mensajes por Usuario</h4>
-                <canvas id="grafico"></canvas>
+                <canvas id="grafico" width="600" height="300"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Top Números</h4>
                 <div class="chart-table">
-                    <canvas id="graficoTopNumeros"></canvas>
+                    <canvas id="graficoTopNumeros" width="600" height="300"></canvas>
                     <table id="tabla_top_numeros" class="fixed-table">
                         <thead>
                             <tr>
@@ -99,7 +99,7 @@
             <div class="card chart-card">
                 <h4>Palabras Más Usadas</h4>
                 <div class="chart-table">
-                    <canvas id="grafico_palabras"></canvas>
+                    <canvas id="grafico_palabras" width="600" height="300"></canvas>
                     <table id="tabla_palabras" class="fixed-table">
                         <thead>
                             <tr>
@@ -114,7 +114,7 @@
             <div class="card chart-card">
                 <h4>Roles</h4>
                 <div class="chart-table">
-                    <canvas id="grafico_roles"></canvas>
+                    <canvas id="grafico_roles" width="600" height="300"></canvas>
                     <table id="tabla_roles" class="fixed-table">
                         <thead>
                             <tr>
@@ -128,11 +128,11 @@
             </div>
             <div class="card chart-card">
                 <h4>Tipos de Mensaje</h4>
-                <canvas id="graficoTipos"></canvas>
+                <canvas id="graficoTipos" width="600" height="300"></canvas>
             </div>
             <div class="card chart-card">
                 <h4>Tipos por Día</h4>
-                <canvas id="graficoTiposDiarios"></canvas>
+                <canvas id="graficoTiposDiarios" width="600" height="300"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- set explicit dimensions for dashboard canvases in CSS and HTML
- disable Chart.js responsiveness so fixed sizes are honored

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5f349ecb88323a4ca653c6bea0498