### PR TITLE
Enable responsive charts

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -12,8 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
-    maintainAspectRatio: false,
-    responsive: false
+    maintainAspectRatio: true,
+    responsive: true
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');


### PR DESCRIPTION
## Summary
- make Chart.js charts responsive by enabling `responsive` option and maintaining aspect ratio
- ensure all Chart instances inherit the shared `commonOptions`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f4e2549c83239ecf3e92d5afc569