### PR TITLE
Make tablero charts responsive

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -63,15 +63,17 @@
 
 
 .card canvas {
-  width: 600px;
-  height: 300px;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 2 / 1;
   display: block;
   margin: 0 auto;
 }
 
 .chart-card canvas {
-  width: 600px;
-  height: 300px;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 2 / 1;
 }
 
 .chart-table {


### PR DESCRIPTION
## Summary
- Make tablero canvas charts responsive by replacing fixed 600x300 dimensions with width 100% and aspect-ratio 2:1.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f599f1448323a2309f5bcec4266a