### PR TITLE
Fix dashboard chart canvas dimensions

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -83,9 +83,9 @@
 }
 
 .chart-card canvas {
-  width: 100%;
-  height: auto;
-  aspect-ratio: 2 / 1;
+  width: 600px;
+  height: 350px;
+  flex: none;
 }
 
 .chart-table {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -85,7 +85,7 @@
                         <span class="icon">📅</span>
                         <h4>Mensajes por Día</h4>
                     </div>
-                    <canvas id="graficoDiario" width="600" height="300"></canvas>
+                    <canvas id="graficoDiario"></canvas>
                     <table id="tabla_dia_semana" class="fixed-table">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
@@ -96,7 +96,7 @@
                         <span class="icon">⏰</span>
                         <h4>Mensajes por Hora</h4>
                     </div>
-                    <canvas id="graficoHora" width="600" height="300"></canvas>
+                    <canvas id="graficoHora"></canvas>
                 </div>
             </div>
             <div class="card chart-card">
@@ -104,14 +104,14 @@
                     <span class="icon">📊</span>
                     <h3>Totales de mensajes</h3>
                 </div>
-                <canvas id="graficoTotales" width="600" height="300"></canvas>
+                <canvas id="graficoTotales"></canvas>
             </div>
             <div class="card chart-card">
                 <div class="card-header">
                     <span class="icon">👤</span>
                     <h4>Mensajes por Usuario</h4>
                 </div>
-                <canvas id="grafico" width="600" height="300"></canvas>
+                <canvas id="grafico"></canvas>
             </div>
             <div class="card chart-card">
                 <div class="card-header">
@@ -119,7 +119,7 @@
                     <h4>Top Números</h4>
                 </div>
                 <div class="chart-table">
-                    <canvas id="graficoTopNumeros" width="600" height="300"></canvas>
+                    <canvas id="graficoTopNumeros"></canvas>
                     <table id="tabla_top_numeros" class="fixed-table">
                         <thead>
                             <tr>
@@ -137,7 +137,7 @@
                     <h4>Palabras Más Usadas</h4>
                 </div>
                 <div class="chart-table">
-                    <canvas id="grafico_palabras" width="600" height="300"></canvas>
+                    <canvas id="grafico_palabras"></canvas>
                     <table id="tabla_palabras" class="fixed-table">
                         <thead>
                             <tr>
@@ -155,7 +155,7 @@
                     <h4>Roles</h4>
                 </div>
                 <div class="chart-table">
-                    <canvas id="grafico_roles" width="600" height="300"></canvas>
+                    <canvas id="grafico_roles"></canvas>
                     <table id="tabla_roles" class="fixed-table">
                         <thead>
                             <tr>
@@ -172,14 +172,14 @@
                     <span class="icon">💬</span>
                     <h4>Tipos de Mensaje</h4>
                 </div>
-                <canvas id="graficoTipos" width="600" height="300"></canvas>
+                <canvas id="graficoTipos"></canvas>
             </div>
             <div class="card chart-card">
                 <div class="card-header">
                     <span class="icon">🗓️</span>
                     <h4>Tipos por Día</h4>
                 </div>
-                <canvas id="graficoTiposDiarios" width="600" height="300"></canvas>
+                <canvas id="graficoTiposDiarios"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- give `.chart-card canvas` a fixed 600x350 size so charts don't crop
- remove `width`/`height` attributes from dashboard templates to let CSS control sizing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f7abd16c83238c51c094358dd704