### PR TITLE
Center chart canvas and reduce size

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -49,6 +49,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: center;
   gap: 12px;
   overflow: hidden;
 }
@@ -83,8 +84,8 @@
 }
 
 .chart-card canvas {
-  width: 600px;
-  height: 350px;
+  width: 450px;
+  height: 250px;
   flex: none;
 }
 


### PR DESCRIPTION
## Summary
- Center chart canvas within chart-card using `align-items: center`
- Shrink chart canvas dimensions to 450x250

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa653ae88323b5c3aece5b85be0c