### PR TITLE
Adjust chart card layout

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -45,10 +45,9 @@
 .chart-card {
   width: 100%;
   height: auto;
-  min-height: 240px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   gap: 12px;
   overflow: hidden;
@@ -84,8 +83,8 @@
 }
 
 .chart-card canvas {
-  width: 450px;
-  height: 250px;
+  width: 100%;
+  height: auto;
   flex: none;
 }
 


### PR DESCRIPTION
## Summary
- make chart cards flex-start and remove min-height for tighter spacing
- allow chart canvas to fill container with responsive width/height

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5fbdcf65c8323bb53d82b3099d40f