### PR TITLE
Ensure charts respect card height constraints

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -86,6 +86,8 @@
 .chart-card canvas {
   width: 100%;
   height: auto;
+  max-height: 300px;
+  aspect-ratio: auto;
   flex: none;
 }
 

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
-    maintainAspectRatio: true,
+    maintainAspectRatio: false,
     responsive: true
   };
   const startInput = document.getElementById('fechaInicio');


### PR DESCRIPTION
## Summary
- Limit chart canvases to a maximum height and remove forced aspect ratio so cards scale better
- Allow Chart.js charts to ignore internal aspect ratio and adapt to CSS height

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6609db7548323a47a704e4ad9abb7