### PR TITLE
Adjust chart layout to respect canvas height

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -78,7 +78,6 @@
 .card canvas {
   width: 100%;
   height: auto;
-  aspect-ratio: 2 / 1;
   display: block;
   margin: 0 auto;
 }
@@ -97,9 +96,13 @@
   align-items: stretch;
 }
 
-.chart-table canvas,
-.chart-table table:not(.fixed-table) {
-  flex: 1;
+.chart-table canvas {
+  flex: 1 1 50%;
+  max-width: 50%;
+}
+
+.chart-table .fixed-table {
+  flex: 1 1 50%;
 }
 
 .wide-row {

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
+    // Allow charts to respect the explicit canvas height
     maintainAspectRatio: false,
     responsive: true
   };


### PR DESCRIPTION
## Summary
- Ensure Chart.js charts respect canvas height by keeping `maintainAspectRatio` disabled
- Style chart-table containers so canvas and tables share width evenly
- Remove fixed aspect ratio from card canvases

## Testing
- `python -m pytest`
- `python app.py` (start server)


------
https://chatgpt.com/codex/tasks/task_e_68b66261208c8323b14f04a57eac82c2