### PR TITLE
Remove weekly table from dashboard

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -226,31 +226,6 @@ document.addEventListener('DOMContentLoaded', () => {
         showCardMessage('graficoDiario', 'Error al cargar datos');
       });
 
-    fetch(`/datos_mensajes_semana${query}`)
-      .then(response => response.json())
-      .then(data => {
-        const tabla = document.getElementById('tabla_dia_semana');
-        if (!tabla) return;
-        const tbody = tabla.querySelector('tbody');
-        tbody.innerHTML = '';
-        if (!Array.isArray(data) || data.length === 0) return;
-        data.forEach(item => {
-          const row = document.createElement('tr');
-          const diaCell = document.createElement('td');
-          diaCell.textContent = item.dia;
-          const totalCell = document.createElement('td');
-          totalCell.textContent = item.total;
-          row.appendChild(diaCell);
-          row.appendChild(totalCell);
-          tbody.appendChild(row);
-        });
-      })
-      .catch(err => {
-        console.error(err);
-        const tabla = document.getElementById('tabla_dia_semana');
-        if (tabla) tabla.querySelector('tbody').innerHTML = '';
-      });
-
     fetch(`/datos_mensajes_hora${query}`)
       .then(response => response.json())
       .then(data => {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -87,10 +87,6 @@
                         <h4>Mensajes por Día</h4>
                     </div>
                     <canvas id="graficoDiario"></canvas>
-                    <table id="tabla_dia_semana" class="fixed-table">
-                        <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
-                        <tbody></tbody>
-                    </table>
                 </div>
                 <div class="card chart-card">
                     <div class="card-header">


### PR DESCRIPTION
## Summary
- drop unused 'Mensajes por Día' table from dashboard template
- eliminate weekly messages fetch and table population logic in tablero.js

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node - <<'NODE'...`

------
https://chatgpt.com/codex/tasks/task_e_68b668d975a4832382ffed9cdd09c726