### PR TITLE
Hide filters panel until expanded

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -133,14 +133,14 @@
   overflow: hidden;
   transition: max-height 0.3s ease;
   background: #fff;
-  border: 1px solid var(--border-color);
   border-radius: 8px;
-  padding: 1rem;
-  margin-bottom: 1rem;
 }
 
 .filters-panel.open {
   max-height: 500px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--border-color);
 }
 
 .filters-panel label,


### PR DESCRIPTION
## Summary
- Remove padding, margin and border from collapsed filters panel
- Add those styles when panel has `open` state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66b55dedc8323819a6b1c483d353c