### PR TITLE
Reduce chart canvas height and add width constraint

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -85,7 +85,9 @@
 .chart-card canvas {
   width: 100%;
   height: auto;
-  max-height: 300px;
+  max-width: 90%;
+  max-height: 250px;
+  margin: 0 auto;
   aspect-ratio: auto;
   flex: none;
 }


### PR DESCRIPTION
## Summary
- limit chart canvas height to 250px and width to 90%
- center canvases within chart cards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66cff8aa88323b421c93404c09c73