### PR TITLE
Registra estado 'sin_regla' y resalta chat en rojo

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -134,6 +134,7 @@ def process_step_chain(numero, text_norm=None):
 
     logging.warning("Fallback en step '%s' para entrada '%s'", step, text_norm)
     enviar_mensaje(numero, DEFAULT_FALLBACK_TEXT)
+    update_chat_state(numero, get_current_step(numero), 'sin_regla')
 
 
 @register_handler('barra_medida')

--- a/static/style.css
+++ b/static/style.css
@@ -139,7 +139,7 @@
       justify-content: center;   /* centra el contenido */
       pointer-events: none;
     }
-    .estado-sin_regla { background-color: orange; color: var(--text-light); }
+    .estado-sin_regla { background-color: #ff4d4f; color: var(--text-light); }
     .estado-espera_usuario { background-color: green; color: var(--text-light); }
     .estado-asesor { background-color: yellow; color: var(--text-main); }
 


### PR DESCRIPTION
## Summary
- Log state `sin_regla` after fallback responses in webhook step processing
- Style chats without matching rule in red for visibility

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6e92aff048323ad51b9490eb1d2f4