### PR TITLE
Support next steps per menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Importación de reglas y botones desde archivos .xlsx
 
 Soporte para mensajes interactivos: texto, botones y listas desplegables
 
-Ejemplo de `opciones` para una lista con textos personalizados:
+Ejemplo de `opciones` para una lista con textos personalizados y paso destino:
 
 ```json
 {
@@ -71,12 +71,14 @@ Ejemplo de `opciones` para una lista con textos personalizados:
     {
       "title": "Rápido",
       "rows": [
-        {"id": "express", "title": "Express", "description": "1 día"}
+        {"id": "express", "title": "Express", "description": "1 día", "step": "cotizacion"}
       ]
     }
   ]
 }
 ```
+
+Cada fila puede incluir un campo opcional `step` que indica el paso destino al seleccionar esa opción.
 
 Detección de inactividad para cerrar sesión automática del cliente
 

--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -64,6 +64,16 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             print("[WA API] Lista vacía; enviando mensaje de texto de fallback")
             return enviar_mensaje(numero, fallback, tipo, 'texto', None, reply_to_wa_id)
 
+        sections_clean = []
+        for sec in sections:
+            rows_clean = []
+            for row in sec.get("rows", []):
+                row_clean = {k: v for k, v in row.items() if k not in {"step", "next_step"}}
+                rows_clean.append(row_clean)
+            sec_clean = {k: v for k, v in sec.items() if k != "rows"}
+            sec_clean["rows"] = rows_clean
+            sections_clean.append(sec_clean)
+
         data = {
             "messaging_product": "whatsapp",
             "to": numero,
@@ -75,7 +85,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
                 "footer": {"text": footer},
                 "action": {
                     "button": button,
-                    "sections": sections
+                    "sections": sections_clean
                 }
             }
         }
@@ -85,6 +95,10 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             botones = json.loads(opciones) if opciones else []
         except Exception:
             botones = []
+        botones_clean = []
+        for b in botones:
+            btn_clean = {k: v for k, v in b.items() if k not in {"step", "next_step"}}
+            botones_clean.append(btn_clean)
         data = {
             "messaging_product": "whatsapp",
             "to": numero,
@@ -92,7 +106,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             "interactive": {
                 "type": "button",
                 "body": {"text": mensaje},
-                "action": {"buttons": botones}
+                "action": {"buttons": botones_clean}
             }
         }
 


### PR DESCRIPTION
## Summary
- allow mapping each interactive menu option to its own `siguiente_step`
- strip internal `step` fields before sending interactive messages to WhatsApp API
- document how to include `step` in menu options

## Testing
- `python -m py_compile routes/webhook.py services/whatsapp_api.py`
- `python - <<'PY'
from routes.webhook import _get_step_from_options
import json
opts = {
    "sections": [
        {"title": "Menu","rows": [
            {"id": "cotizar", "title": "Cotizar", "step": "cotizacion"},
            {"id": "tiquetes", "title": "Tiquetes", "step": "origen"}
        ]}
    ]
}
print('cotizar ->', _get_step_from_options(json.dumps(opts), 'cotizar'))
print('tiquetes ->', _get_step_from_options(json.dumps(opts), 'tiquetes'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b7015e4e2c8323805225e6161be4c7