### PR TITLE
Clarify next step can contain multiple comma-separated steps

### DIFF
--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -23,8 +23,8 @@
     <label for="respuesta">Respuesta del bot:</label>
     <textarea id="respuesta" name="respuesta" rows="4" required></textarea>
 
-    <label for="siguiente_step">Siguiente paso:</label>
-    <input type="text" id="siguiente_step" name="siguiente_step">
+    <label for="siguiente_step">Siguiente paso (puedes ingresar varios pasos separados por comas):</label>
+    <input type="text" id="siguiente_step" name="siguiente_step" placeholder="paso1, paso2">
 
     <label for="tipo">Tipo:</label>
     <select name="tipo" id="tipo" class="form-control">

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -23,8 +23,8 @@
     <label for="respuesta">Respuesta del bot:</label>
     <textarea id="respuesta" name="respuesta" rows="4" required></textarea>
 
-    <label for="siguiente_step">Siguiente paso:</label>
-    <input type="text" id="siguiente_step" name="siguiente_step">
+    <label for="siguiente_step">Siguiente paso (puedes ingresar varios pasos separados por comas):</label>
+    <input type="text" id="siguiente_step" name="siguiente_step" placeholder="paso1, paso2">
 
     <label for="tipo">Tipo:</label>
     <select name="tipo" id="tipo" class="form-control">


### PR DESCRIPTION
## Summary
- Mention that `siguiente_step` accepts multiple comma-separated steps
- Add a placeholder illustrating multiple steps in `siguiente_step` field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b70c333ed48323ab78b276bbb595bd