### PR TITLE
feat: refresh chat list periodically

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -383,6 +383,8 @@
 
       // Inicializa
       fetchChatList();
+      setInterval(fetchChatList, 5000); // intervalo según necesidad
+      // TODO: sustituir el sondeo por WebSockets o Server-Sent Events para actualizaciones en tiempo real
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add periodic refresh of chat list to keep sidebar updated in real time
- Note possibility to replace polling with WebSockets or Server-Sent Events

## Testing
- `python -m pytest`
- `node test_interval.js` (script executed inline)

------
https://chatgpt.com/codex/tasks/task_e_68b71e3bf6348323a58ba11813ca147d