### PR TITLE
Enable drag-and-drop chat role assignment

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -310,6 +310,29 @@
       pointer-events: none;
     }
 
+    .role-drop-zone {
+      position: fixed;
+      bottom: 8px;
+      left: 8px;
+      display: flex;
+      gap: 8px;
+    }
+
+    .role-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
+
+    .role-icon.drag-over {
+      background: var(--accent-hover);
+    }
+
     /* Generic form and table styles for admin pages */
     form, table {
       background: var(--text-light);

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,10 @@
       </div>
       <input id="buscador" type="text" placeholder="Buscar número…">
       <ul id="chatList"></ul>
+      <div class="role-drop-zone">
+        <div class="role-icon" data-role="ticket">🎟️</div>
+        <div class="role-icon" data-role="cotizar">📝</div>
+      </div>
     </div>
 
     <!-- Chat Window -->
@@ -59,6 +63,21 @@
       const replyAction = document.getElementById('replyAction');
       const userRole   = "{{ rol }}";
       const userRoleId = {{ role_id | tojson }};
+
+      document.querySelectorAll('.role-icon').forEach(icon => {
+        icon.addEventListener('dragover', e => {
+          e.preventDefault();
+          icon.classList.add('drag-over');
+        });
+        icon.addEventListener('dragleave', () => icon.classList.remove('drag-over'));
+        icon.addEventListener('drop', e => {
+          e.preventDefault();
+          icon.classList.remove('drag-over');
+          const numero = e.dataTransfer.getData('text/plain');
+          fetch('/assign_chat_role', {method:'POST', body: JSON.stringify({numero, role: icon.dataset.role})})
+            .then(() => fetchChatList());
+        });
+      });
 
       document.addEventListener('click', () => contextMenu.classList.remove('show'));
 
@@ -114,6 +133,11 @@
               const li = document.createElement('li');
               li.textContent = c.alias ? `${c.alias} (${c.numero})` : c.numero;
               if (c.estado) li.classList.add('estado-' + c.estado);
+
+              li.draggable = true;
+              li.addEventListener('dragstart', e => {
+                e.dataTransfer.setData('text/plain', c.numero);
+              });
 
               // Badge con inicial del rol
               if (c.inicial_rol) {


### PR DESCRIPTION
## Summary
- Add role drop zone with ticket and cotizar icons on chat list
- Make chat list items draggable and assign roles via drag-and-drop
- Style drop zone and icons for visibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc58762de483239d36697a22f99a4c