### PR TITLE
feat: label role drop zone icons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -315,18 +315,20 @@
       bottom: 8px;
       left: 8px;
       display: flex;
-      gap: 8px;
+      gap: 12px;
     }
 
     .role-icon {
-      width: 40px;
-      height: 40px;
-      border-radius: 50%;
+      min-width: 60px;
+      height: 60px;
+      border-radius: 12px;
       background: var(--accent);
       display: flex;
       align-items: center;
       justify-content: center;
       cursor: pointer;
+      font-size: 24px;
+      padding: 0 12px;
     }
 
     .role-icon.drag-over {

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,8 +21,8 @@
       <input id="buscador" type="text" placeholder="Buscar número…">
       <ul id="chatList"></ul>
       <div class="role-drop-zone">
-        <div class="role-icon" data-role="ticket">🎟️</div>
-        <div class="role-icon" data-role="cotizar">📝</div>
+        <div class="role-icon" data-role="ticket">🎟️ Tiquetes</div>
+        <div class="role-icon" data-role="cotizar">📝 Cotizar</div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Add text labels alongside emoji icons in the role drop zone
- Enlarge and style role icons to fit labels and improve spacing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5afff2108323b3dc599a7d2aed05