### PR TITLE
Play alert sound for client and bot messages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -315,8 +315,13 @@
               }
 
               chatBoxEl.appendChild(div);
+
+              if (bubble !== 'asesor') {
+                const mediaPlaying = Array.from(chatBoxEl.querySelectorAll('audio, video')).some(m => !m.paused);
+                if (!mediaPlaying) playAlertSound();
+              }
+              lastCount = i + 1;
             }
-            lastCount = total;
             if (atBottom) chatBoxEl.scrollTop = chatBoxEl.scrollHeight;
           });
       }


### PR DESCRIPTION
## Summary
- Play notification sound for each new client or bot message
- Skip alert if audio or video is playing
- Track processed messages while looping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc6491b1688323a2fd3c5d8f648873