### PR TITLE
Notify on new chat messages via timestamps

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -208,13 +208,14 @@ def get_chat_list():
         fila = c.fetchone()
         alias = fila[0] if fila else None
 
-        # Último mensaje para asesor
+        # Último mensaje y su timestamp
         c.execute(
-            "SELECT mensaje FROM mensajes WHERE numero = %s "
+            "SELECT mensaje, timestamp FROM mensajes WHERE numero = %s "
             "ORDER BY timestamp DESC LIMIT 1",
             (numero,)
         )
         fila = c.fetchone()
+        last_ts = fila[1].isoformat() if fila and fila[1] else None
         ultimo = fila[0] if fila else ""
         requiere_asesor = "asesor" in ultimo.lower()
 
@@ -250,6 +251,7 @@ def get_chat_list():
             "roles": roles,
             "inicial_rol": inicial_rol,
             "estado": estado,
+            "last_timestamp": last_ts,
         })
 
     conn.close()

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,10 +61,11 @@
       const replyPreviewEl = document.getElementById('replyPreview');
       const contextMenu = document.getElementById('contextMenu');
       const replyAction = document.getElementById('replyAction');
-      const userRole   = "{{ rol }}";
-      const userRoleId = {{ role_id | tojson }};
+        const userRole   = "{{ rol }}";
+        const userRoleId = {{ role_id | tojson }};
+        const lastChatTimestamps = {};
 
-      function playAlertSound() {
+        function playAlertSound() {
         const ctx = new (window.AudioContext || window.webkitAudioContext)();
         const oscillator = ctx.createOscillator();
         const gain = ctx.createGain();
@@ -143,17 +144,18 @@
           .then(data=>{
             todosChats = data;
             chatListEl.innerHTML='';
-            let alertPlayed = false;
             data.forEach(c => {
               if (userRole !== 'admin') {
                 const roles = c.roles ? c.roles.split(',').map(Number) : [];
                 if (!roles.includes(userRoleId)) return;
               }
-              if (!alertPlayed && c.estado === 'sin_regla') {
+              const serverTime = c.last_timestamp ? new Date(c.last_timestamp).getTime() : null;
+              const prevTime = lastChatTimestamps[c.numero];
+              if (serverTime && prevTime && serverTime > prevTime && c.numero !== currentChat) {
                 const mediaPlaying = Array.from(document.querySelectorAll('audio, video')).some(m => !m.paused);
                 if (!mediaPlaying) playAlertSound();
-                alertPlayed = true;
               }
+              if (serverTime) lastChatTimestamps[c.numero] = serverTime;
               const li = document.createElement('li');
               li.textContent = c.alias ? `${c.alias} (${c.numero})` : c.numero;
               if (c.estado) li.classList.add('estado-' + c.estado);


### PR DESCRIPTION
## Summary
- include last message timestamp in `/get_chat_list`
- track per-chat last message timestamps on the client
- play alert sound for unseen new messages

## Testing
- `python -m py_compile routes/chat_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc668553808323a0412c9549362aac