### PR TITLE
Load chat roles from database

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -68,8 +68,12 @@ def index():
     )
     botones = c.fetchall()
 
+    # Roles disponibles (excluyendo admin)
+    c.execute("SELECT id, name, keyword FROM roles WHERE keyword != 'admin'")
+    roles_db = c.fetchall()
+
     conn.close()
-    return render_template('index.html', chats=chats, botones=botones, rol=rol, role_id=role_id)
+    return render_template('index.html', chats=chats, botones=botones, rol=rol, role_id=role_id, roles=roles_db)
 
 @chat_bp.route('/get_chat/<numero>')
 def get_chat(numero):
@@ -301,7 +305,7 @@ def assign_chat_role():
             """
             DELETE FROM chat_roles
             WHERE numero = %s AND role_id IN (
-                SELECT id FROM roles WHERE keyword IN ('ticket','cotizar')
+                SELECT id FROM roles WHERE keyword != 'admin'
             )
             """,
             (numero,),

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,8 +21,9 @@
       <input id="buscador" type="text" placeholder="Buscar número…">
       <ul id="chatList"></ul>
       <div class="role-drop-zone">
-        <div class="role-icon" data-role="ticket">🎟️ Tiquetes</div>
-        <div class="role-icon" data-role="cotizar">📝 Cotizar</div>
+        {% for r in roles %}
+        <div class="role-icon" data-role="{{ r[2] }}">{{ r[1] }}</div>
+        {% endfor %}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Load available roles (excluding admin) in the chat index view and render them dynamically
- Remove non-admin roles when assigning a new chat role

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c6a4d348323ad77e6540851b1da