### PR TITLE
Fix role drop zone positioning and icon color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -311,7 +311,7 @@
     }
 
     .role-drop-zone {
-      position: fixed;
+      position: absolute;
       bottom: 8px;
       left: 8px;
       display: flex;
@@ -328,6 +328,7 @@
       justify-content: center;
       cursor: pointer;
       font-size: 24px;
+      color: var(--text-light);
       padding: 0 12px;
     }
 


### PR DESCRIPTION
## Summary
- Position `.role-drop-zone` relative to the sidebar by using `position: absolute`.
- Make role icon text white with `color: var(--text-light)`.

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68bcaf2fa85c8323bffaf52968f6316a