### PR TITLE
Translate weekday names to Spanish

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -437,8 +437,17 @@ def datos_mensajes_semana():
     cur.execute(query, params)
     rows = cur.fetchall()
     conn.close()
+    day_map = {
+        "Monday": "Lunes",
+        "Tuesday": "Martes",
+        "Wednesday": "Miércoles",
+        "Thursday": "Jueves",
+        "Friday": "Viernes",
+        "Saturday": "Sábado",
+        "Sunday": "Domingo",
+    }
 
-    data = [{"dia": dia, "total": total} for dow, dia, total in rows]
+    data = [{"dia": day_map.get(dia, dia), "total": total} for dow, dia, total in rows]
     return jsonify(data)
 
 


### PR DESCRIPTION
## Summary
- Map English weekday names to Spanish in the `/datos_mensajes_semana` endpoint
- Return `dia` values in Spanish in the JSON response

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb596cb8c8323bf18989cdfb0f353